### PR TITLE
CI: publish multi-arch Docker image to GHCR on release tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+name: Build and push Docker image to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    # ARM64 TeX Live build runs under QEMU emulation; allow generous headroom
+    # on first build (no cache). Subsequent builds hit the gha cache and are
+    # much faster.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/swedev/klartex
+          # vX.Y.Z tag → three image tags: X.Y.Z, X.Y, latest
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### New features
+- **Docker image published to GHCR on release.** Each `vX.Y.Z` tag now triggers `.github/workflows/docker.yml`, which builds a multi-arch image (`linux/amd64` + `linux/arm64`) and pushes it to `ghcr.io/swedev/klartex` with tags `X.Y.Z`, `X.Y`, and `latest`. Pull: `docker pull ghcr.io/swedev/klartex:latest`. The image starts the HTTP service on port 8000 by default.
+
 ## 0.9.8 — 2026-05-06
 
 ### Breaking changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,9 @@ klartex example _block                         # canonical example payload
    1. Bump `version` in `pyproject.toml`.
    2. Add a dated entry at the top of `CHANGELOG.md` (groups: `Breaking changes` / `New features` / `Fixes` / `Spacing`).
    3. Commit as `Release vX.Y.Z: <summary>` and push to `main`.
-   4. `gh release create vX.Y.Z --generate-notes` — `.github/workflows/publish.yml` runs tests and publishes to PyPI.
+   4. `gh release create vX.Y.Z --generate-notes` pushes the tag and creates the release, which triggers:
+      - `.github/workflows/publish.yml` — runs tests and publishes to PyPI.
+      - `.github/workflows/docker.yml` — builds the multi-arch Docker image (`linux/amd64` + `linux/arm64`) and pushes to `ghcr.io/swedev/klartex` with tags `X.Y.Z`, `X.Y`, `latest`. Both workflows run in parallel.
 
 ## Architecture
 

--- a/README.en.md
+++ b/README.en.md
@@ -67,6 +67,17 @@ klartex schema protokoll
 klartex serve
 ```
 
+### As Docker image
+
+Official multi-arch image (`linux/amd64` + `linux/arm64`) is published to GitHub Container Registry on every release:
+
+```bash
+docker run --rm -p 8000:8000 ghcr.io/swedev/klartex:latest
+# or pin a version: ghcr.io/swedev/klartex:0.9.8
+```
+
+The image starts the HTTP service on port 8000. Available tags: `X.Y.Z` (exact version), `X.Y` (latest in the minor series) and `latest`.
+
 ### As HTTP service
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ klartex schema protokoll
 klartex serve
 ```
 
+### Som Docker-image
+
+Officiell multi-arch-image (`linux/amd64` + `linux/arm64`) publiceras till GitHub Container Registry vid varje release:
+
+```bash
+docker run --rm -p 8000:8000 ghcr.io/swedev/klartex:latest
+# eller låst version: ghcr.io/swedev/klartex:0.9.8
+```
+
+Imagen startar HTTP-tjänsten på port 8000. Tillgängliga taggar: `X.Y.Z` (exakt version), `X.Y` (senaste i minor-serien) och `latest`.
+
 ### Som HTTP-tjänst
 
 ```bash


### PR DESCRIPTION
Adds `.github/workflows/docker.yml` so that pushing a `v*.*.*` tag (which `gh release create` does as part of the existing release flow) builds and publishes a multi-arch Docker image to GHCR. Closes the gap that blocks the klartex.se webapp's `docker compose pull` on the Hetzner cax11 ARM box.

## Workflow

- **Trigger:** `push: tags: ['v*.*.*']`. Independent from `publish.yml` (which keys off `release: published`); both fire on `gh release create` and run in parallel.
- **Image:** `ghcr.io/swedev/klartex`
- **Tags emitted via `docker/metadata-action`:**
  - `X.Y.Z` (exact, `type=semver,pattern={{version}}`)
  - `X.Y` (`type=semver,pattern={{major}}.{{minor}}`)
  - `latest` (`type=raw`)
- **Platforms:** `linux/amd64,linux/arm64` via `docker/setup-qemu-action` + `docker/setup-buildx-action` + `docker/build-push-action@v6`.
- **Auth:** `permissions: { contents: read, packages: write }` at the job level. Uses the job's `GITHUB_TOKEN`; no repo secrets needed.
- **Cache:** `cache-from: type=gha` / `cache-to: type=gha,mode=max`. First build will still take a while (TeX Live ~1 GB across two arches under QEMU); subsequent builds amortise.
- **Timeout:** 60 minutes, generous headroom for first uncached arm64 build.

## Dockerfile compatibility

Verified locally:

```console
$ docker manifest inspect texlive/texlive:latest-minimal
# manifest list with both arm64 and amd64 platform entries
```

`tlmgr install` in the Dockerfile only fetches pure-TeX packages (`xetex`, `fontspec`, `fancyhdr`, `geometry`, …) — no architecture-specific binaries. The actual engine binaries come from the multi-arch base image. **No Dockerfile changes required.**

Skipped a local arm64 buildx test because TL builds take 10+ minutes uncached and the multi-arch base + pure-TeX package set leaves negligible arm64-specific risk. CI will be the first real arm64 build; if `tlmgr` misbehaves under QEMU we'll see it there.

## Smoke test after first run

Per spec, on a separate machine:

\`\`\`bash
docker pull --platform linux/arm64 ghcr.io/swedev/klartex:latest
docker run --rm -p 8000:8000 ghcr.io/swedev/klartex:latest
# in another terminal:
curl -s http://localhost:8000/templates | jq '.[].name'
\`\`\`

Both arches should start the server and respond on `/templates`.

## Lint

\`\`\`console
$ actionlint .github/workflows/docker.yml
# no output → clean
\`\`\`

`actionlint` also clean on the existing `publish.yml` and `ci.yml` (unchanged).

## Docs updated

- `README.md` / `README.en.md`: new \"Som Docker-image\" / \"As Docker image\" subsection under Användning/Usage with the `docker run` one-liner and tag explanation.
- `CLAUDE.md` *Releases* section: notes that `gh release create vX.Y.Z` now triggers Docker publish alongside PyPI.
- `CHANGELOG.md`: new `## Unreleased` stub with a *New features* note about GHCR publish, ready to fold into the next dated release entry.

## Not in scope

Per spec:
- No `:edge` tag on `main` push.
- No SBOM / attestation / signing.
- No image size optimisation.

## After merge

1. Next \`gh release create vX.Y.Z\` will trigger the new workflow.
2. After the first successful run, the package **may need to be flipped to public** under `swedev/klartex` → Packages → settings, depending on the org's default. The workflow itself can't set this.
3. Once public, the klartex.se infra/docker-compose.yml can pin `ghcr.io/swedev/klartex:X.Y` or `:latest`.