### PR TITLE
asset_dir-parameter på render()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.11.1 — 2026-05-11
+
+### New features
+- **`render(asset_dir=...)`-parameter.** `klartex.render()` accepterar nu en valfri `asset_dir: Path | str | None`. Katalogen läggs in i `TEXINPUTS` mellan den bundlade `cls/`-mappen och anroparens cwd, så `\includegraphics`, `\input`, custom fonts m.m. i en sidmall hittas där utan att anroparen behöver `chdir`. Tänkt huvudanvändning: serverlager (t.ex. `klartex.se`) som slår upp namngivna sidmalls-bundles i en lokal katalog och vill peka klartex på den utan globala sidoeffekter.
+
 ## 0.11.0 — 2026-05-11
 
 ### Breaking changes

--- a/klartex/renderer.py
+++ b/klartex/renderer.py
@@ -62,6 +62,7 @@ def render(
     template_name: str,
     data: dict,
     page_template_source: str | None = None,
+    asset_dir: Path | str | None = None,
 ) -> bytes:
     """Render a template with data to PDF bytes.
 
@@ -71,6 +72,11 @@ def render(
         page_template_source: Optional raw .tex.jinja content for the page
             template. When set, this is used directly instead of looking up
             the built-in page template from data["page_template"].
+        asset_dir: Optional directory injected into TEXINPUTS so xelatex
+            resolves `\\includegraphics`, `\\input`, custom fonts, etc.
+            against it. Searched between the bundled `cls/` and the caller's
+            cwd. Useful when callers (e.g. a server) keep page-template
+            bundles in a known location separate from the working directory.
 
     Returns:
         PDF file contents as bytes
@@ -123,11 +129,11 @@ def render(
         # fails to match the dispatch). Also restore raw source on latex blocks.
         _restore_block_types(data.get("body", []), escaped_data["body"])
         tex_source = _render_block_engine(escaped_data, page_template_source)
-        return _compile_tex(tex_source)
+        return _compile_tex(tex_source, asset_dir=asset_dir)
 
     # Recipe path
     tex_source = _render_recipe(template_info, escaped_data, page_template_source)
-    return _compile_tex(tex_source)
+    return _compile_tex(tex_source, asset_dir=asset_dir)
 
 
 def _restore_block_types(orig_blocks: list, esc_blocks: list) -> None:
@@ -181,7 +187,7 @@ def _render_recipe(
     return template.render(context)
 
 
-def _compile_tex(tex_source: str) -> bytes:
+def _compile_tex(tex_source: str, asset_dir: Path | str | None = None) -> bytes:
     """Compile LaTeX source to PDF bytes."""
     if not shutil.which("xelatex"):
         raise RuntimeError(
@@ -201,13 +207,16 @@ def _compile_tex(tex_source: str) -> bytes:
         # Also symlink klartex-base.cls at top level for \documentclass{klartex-base}
         (tmp / "klartex-base.cls").symlink_to(CLS_DIR / "klartex-base.cls")
 
-        # Build environment with cls/ and caller's cwd on TEXINPUTS
+        # Build environment with cls/, optional asset_dir, and caller's cwd
+        # on TEXINPUTS. asset_dir slots in after the bundled cls/ so server
+        # callers can resolve page-template bundles without chdir.
         import os
 
         env = os.environ.copy()
         existing_texinputs = env.get("TEXINPUTS", "")
         cwd = os.getcwd()
-        env["TEXINPUTS"] = f".:{CLS_DIR}:{cwd}:{existing_texinputs}"
+        asset_part = f"{asset_dir}:" if asset_dir is not None else ""
+        env["TEXINPUTS"] = f".:{CLS_DIR}:{asset_part}{cwd}:{existing_texinputs}"
 
         # Run xelatex twice (for page references).
         # -no-shell-escape disables \write18 and shell command execution from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "klartex"
-version = "0.11.0"
+version = "0.11.1"
 description = "PDF generation via LaTeX — structured data in, professional documents out"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -39,6 +39,34 @@ def test_render_with_special_chars():
     assert pdf_bytes[:5] == b"%PDF-"
 
 
+@pytest.mark.skipif(not HAS_XELATEX, reason="xelatex not installed")
+def test_render_resolves_asset_dir(tmp_path):
+    """Files in asset_dir should be resolvable by xelatex via TEXINPUTS."""
+    # Put a snippet only findable through asset_dir
+    (tmp_path / "brand-colors.tex").write_text(
+        r"\definecolor{brandprimary}{HTML}{2E5A1C}"
+    )
+    page_template = (
+        r"\input{brand-colors}"
+        "\n"
+        r"\fancyhead[L]{\color{brandprimary}Test}"
+        "\n"
+        r"\fancyfoot[C]{\thepage}"
+        "\n"
+    )
+    data = {"body": [{"type": "heading", "text": "Asset dir test"}]}
+
+    # With asset_dir: \input resolves, render succeeds
+    pdf = render(
+        "_block", data, page_template_source=page_template, asset_dir=tmp_path
+    )
+    assert pdf[:5] == b"%PDF-"
+
+    # Without asset_dir: \input cannot find brand-colors.tex, xelatex halts
+    with pytest.raises(RuntimeError, match="xelatex failed"):
+        render("_block", data, page_template_source=page_template)
+
+
 class TestDiscovery:
     """Tests for template discovery."""
 


### PR DESCRIPTION
Lägger till `klartex.render(..., asset_dir: Path | str | None = None)`. När satt injiceras katalogen i `TEXINPUTS` mellan den bundlade `cls/`-mappen och anroparens cwd, så att `\includegraphics`, `\input`, custom fonts och liknande som refereras från en sidmall hittas där utan att anroparen måste `chdir`.

## Användning

```python
from pathlib import Path
import klartex

klartex.render(
    \"_block\",
    data,
    page_template_source=(Path(\"branding/vkf\") / \"page_template.tex.jinja\").read_text(),
    asset_dir=Path(\"branding/vkf\"),
)
```

## Diff

- `render()` får `asset_dir` kwarg, vidarebefordras till `_compile_tex`
- `_compile_tex` byter `TEXINPUTS=.:CLS_DIR:cwd:…` mot `TEXINPUTS=.:CLS_DIR:asset_dir:cwd:…` när satt
- Inga andra ändringar (signatur, validering, escape, dispatch oförändrat)

## Tester

`test_render_resolves_asset_dir`: skapar en tempdir med `brand-colors.tex`, en page template som `\input{brand-colors}`, och bekräftar att render lyckas med `asset_dir=tmp_path` och **failar** utan (xelatex halt-on-error). 191/191 grönt totalt.

## Bakgrund

`klartex.se`-backend bygger ett namngivet page-template-register (`page_template: \"vkf\"` → uppslag i lokal katalog). Utan `asset_dir` skulle backend behöva `chdir` + processlock för att xelatex ska hitta logos/snippets. Den här parametern är den lilla saknade kopplingen.

Additive, non-breaking. Bumpar till v0.11.1.