### PR TITLE
Review fixes: cell-safe line breaks, nested validation, contract_intro, CLI hardening

### DIFF
--- a/klartex/cli.py
+++ b/klartex/cli.py
@@ -66,7 +66,10 @@ def main(
         if not data.exists():
             typer.echo(f"Error: data file not found: {data}", err=True)
             raise typer.Exit(1)
-        raw_text = data.read_text()
+        if not data.is_file():
+            typer.echo(f"Error: data path is not a file: {data}", err=True)
+            raise typer.Exit(1)
+        raw_text = data.read_text(encoding="utf-8")
     else:
         if sys.stdin.isatty():
             typer.echo("Error: no data provided. Use -d <file> or pipe JSON to stdin.", err=True)
@@ -79,28 +82,37 @@ def main(
     page_template_source = None
     if page_template is not None:
         pt_path = Path(page_template)
-        if not pt_path.exists():
+        if not pt_path.is_file():
             typer.echo(f"Error: page template file not found: {page_template}", err=True)
             raise typer.Exit(1)
-        page_template_source = pt_path.read_text()
+        page_template_source = pt_path.read_text(encoding="utf-8")
     else:
         auto = _autodetect_page_template(data)
         if auto is not None:
-            page_template_source = auto.read_text()
+            page_template_source = auto.read_text(encoding="utf-8")
             typer.echo(f"Using page template: {auto}", err=True)
 
     # Default output filename: same as input but with .pdf extension
     if output is None:
         output = Path(data.stem + ".pdf") if data is not None else Path("output.pdf")
 
-    raw = json.loads(raw_text)
+    try:
+        raw = json.loads(raw_text)
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error: invalid JSON input: {e}", err=True)
+        raise typer.Exit(1)
+
     try:
         pdf_bytes = render(template, raw, page_template_source=page_template_source)
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
-    output.write_bytes(pdf_bytes)
+    try:
+        output.write_bytes(pdf_bytes)
+    except OSError as e:
+        typer.echo(f"Error: could not write output to {output}: {e}", err=True)
+        raise typer.Exit(1)
     typer.echo(f"Written {len(pdf_bytes)} bytes to {output}")
 
 
@@ -155,7 +167,7 @@ def show_example(
     if not example_path.exists():
         typer.echo(f"Error: no example available for '{template}'", err=True)
         raise typer.Exit(1)
-    typer.echo(example_path.read_text().rstrip())
+    typer.echo(example_path.read_text(encoding="utf-8").rstrip())
 
 
 if __name__ == "__main__":

--- a/klartex/cls/klartex-titelsida.sty
+++ b/klartex/cls/klartex-titelsida.sty
@@ -15,13 +15,22 @@
 
 % Title page command (language-aware)
 % Args: #1=Party1, #2=Party2, #3=Document title
+% Empty party arguments are skipped entirely: with one party the "and"
+% separator is omitted, with no parties only the title renders — no stray
+% "Och" or blank party rows.
 \providecommand{\makedoctitle}[3]{%
     \kx@setlang%
+    \def\kx@tmp@pa{#1}\def\kx@tmp@pb{#2}%
     \begin{center}
         \vspace*{4cm}
-        {\Large\bfseries #1}\\[1em]
-        \kx@and\\[1em]
-        {\Large\bfseries #2}\\[4cm]
+        \ifx\kx@tmp@pa\@empty\else
+            {\Large\bfseries #1}\ifx\kx@tmp@pb\@empty\\[4cm]\else\\[1em]\fi
+        \fi
+        \ifx\kx@tmp@pb\@empty\else
+            \ifx\kx@tmp@pa\@empty\else\kx@and\\[1em]\fi
+            {\Large\bfseries #2}\\[4cm]
+        \fi
+        \ifx\kx@tmp@pa\@empty\ifx\kx@tmp@pb\@empty\vspace*{2cm}\fi\fi
         {\LARGE\bfseries #3}
     \end{center}
     \thispagestyle{fancy}

--- a/klartex/components.py
+++ b/klartex/components.py
@@ -31,7 +31,7 @@ class ComponentSpec:
         path = _SCHEMAS_DIR / self.block_schema_path
         if not path.exists():
             return None
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
 
 
 # Registry of known component types

--- a/klartex/inline_markup.py
+++ b/klartex/inline_markup.py
@@ -34,8 +34,18 @@ _QUOTE_PAIRS = {
 _CODE_PLACEHOLDER = "\x00KX_CODE_{}\x00"
 
 
-def render_inline(text: str, lang: str = "sv") -> str:
-    """Convert inline markup to LaTeX. ``text`` is assumed pre-escaped."""
+def render_inline(text: str, lang: str = "sv", newlines: str = "break") -> str:
+    """Convert inline markup to LaTeX. ``text`` is assumed pre-escaped.
+
+    ``newlines`` selects how literal ``\\n`` characters render:
+
+    - ``"break"`` (default): ``\\\\`` — paragraph line break. NOT safe inside
+      tabular cells, where ``\\\\`` ends the table row instead.
+    - ``"cell"``: ``\\newline`` — in-cell line break for paragraph-mode
+      columns (``p{...}``/``X``).
+    - ``"space"``: collapse to a space — for LR-mode cells (``l`` columns)
+      where no in-cell line break exists.
+    """
     if not text:
         return text
 
@@ -57,7 +67,12 @@ def render_inline(text: str, lang: str = "sv") -> str:
     # breaks within the current paragraph. For separate paragraphs, use
     # separate text blocks. Done last so it doesn't interfere with the regex
     # passes above that operate within a single line.
-    text = text.replace("\n", " \\\\ ")
+    if newlines == "cell":
+        text = text.replace("\n", " \\newline ")
+    elif newlines == "space":
+        text = text.replace("\n", " ")
+    else:
+        text = text.replace("\n", " \\\\ ")
 
     return text
 

--- a/klartex/page_templates.py
+++ b/klartex/page_templates.py
@@ -109,7 +109,7 @@ def read_page_template_source(name: str) -> str:
         FileNotFoundError: If the template file doesn't exist.
     """
     path = PAGE_TEMPLATES_DIR / f"{name}.tex.jinja"
-    return path.read_text()
+    return path.read_text(encoding="utf-8")
 
 
 def list_page_templates() -> list[dict]:

--- a/klartex/page_templates/formal.tex.jinja
+++ b/klartex/page_templates/formal.tex.jinja
@@ -32,7 +32,7 @@
 \fancyfoot[C]{%
     \kx@setlang%
     \fontsize{6pt}{9pt}\selectfont\color{brandsecondary}%
-    \doctitle\ \textbullet\ \kx@page\ \thepage\ \kx@of\ \pageref{LastPage}%
+    \ifdefempty{\doctitle}{}{\doctitle\ \textbullet\ }\kx@page\ \thepage\ \kx@of\ \pageref{LastPage}%
 }
 \makeatother
 \ifdefempty{\orgname}{\ifdefempty{\brandlogo}{%

--- a/klartex/registry.py
+++ b/klartex/registry.py
@@ -41,7 +41,7 @@ def discover_templates(templates_dir: Path) -> dict[str, TemplateInfo]:
         name = schema_path.parent.name
         if name.startswith("_"):
             continue
-        schema = json.loads(schema_path.read_text())
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
         recipe_yaml = schema_path.parent / "recipe.yaml"
         if not recipe_yaml.exists():
@@ -57,7 +57,7 @@ def discover_templates(templates_dir: Path) -> dict[str, TemplateInfo]:
     # Register the block engine as a virtual template
     block_schema_path = _SCHEMAS_DIR / "block_engine.schema.json"
     if block_schema_path.exists():
-        block_schema = json.loads(block_schema_path.read_text())
+        block_schema = json.loads(block_schema_path.read_text(encoding="utf-8"))
 
         # Build discriminated union from per-block schemas for CLI/API display
         from klartex.components import _COMPONENTS

--- a/klartex/renderer.py
+++ b/klartex/renderer.py
@@ -55,7 +55,27 @@ def _inline_filter(ctx, value):
     return render_inline(str(value), lang=ctx.get("lang", "sv"))
 
 
+@jinja2.pass_context
+def _inline_cell_filter(ctx, value):
+    """`inline` for paragraph-mode tabular cells (p/X columns): \\n becomes
+    \\newline, since \\\\ would end the table row instead of the line."""
+    if value is None:
+        return ""
+    return render_inline(str(value), lang=ctx.get("lang", "sv"), newlines="cell")
+
+
+@jinja2.pass_context
+def _inline_flat_filter(ctx, value):
+    """`inline` for LR-mode tabular cells (l columns), where no in-cell
+    line break exists: \\n collapses to a space."""
+    if value is None:
+        return ""
+    return render_inline(str(value), lang=ctx.get("lang", "sv"), newlines="space")
+
+
 _jinja_env.filters["inline"] = _inline_filter
+_jinja_env.filters["inline_cell"] = _inline_cell_filter
+_jinja_env.filters["inline_flat"] = _inline_flat_filter
 
 
 def render(
@@ -95,29 +115,7 @@ def render(
 
     # Validate block types and payloads before escaping (escaping mangles underscores)
     if template_info.is_block_engine:
-        from klartex.block_engine import KNOWN_BLOCK_TYPES
-        from klartex.components import get_component
-
-        for i, block in enumerate(data.get("body", [])):
-            block_type = block.get("type")
-            if not block_type:
-                raise ValueError(f"Block at index {i} is missing 'type'")
-            if block_type not in KNOWN_BLOCK_TYPES:
-                available = ", ".join(sorted(KNOWN_BLOCK_TYPES))
-                raise ValueError(
-                    f"Unknown block type '{block_type}' at index {i}. "
-                    f"Available: {available}"
-                )
-            # Validate block payload against its specific schema
-            spec = get_component(block_type)
-            block_schema = spec.get_block_schema()
-            if block_schema:
-                try:
-                    jsonschema.validate(block, block_schema)
-                except jsonschema.ValidationError as e:
-                    raise ValueError(
-                        f"Invalid '{block_type}' block at index {i}: {e.message}"
-                    ) from e
+        _validate_blocks(data.get("body", []), "body")
 
     # Escape user data for LaTeX safety
     escaped_data = escape_data(data)
@@ -136,12 +134,71 @@ def render(
     return _compile_tex(tex_source, asset_dir=asset_dir)
 
 
+def _child_block_lists(block: dict, path: str = "") -> list[tuple[str, list]]:
+    """Return the nested block carriers of `block` as (path, blocks) pairs.
+
+    Single source of truth for which block types nest other blocks. Both
+    recursive validation and `_restore_block_types` walk these carriers, so
+    any new nesting block only needs to be added here.
+    """
+    btype = block.get("type")
+    if btype == "list":
+        return [
+            (f"{path}.items[{i}].content", item.get("content", []))
+            for i, item in enumerate(block.get("items", []))
+            if isinstance(item, dict)
+        ]
+    if btype == "columns":
+        return [
+            (f"{path}.items[{i}]", col)
+            for i, col in enumerate(block.get("items", []))
+            if isinstance(col, list)
+        ]
+    if btype == "clause":
+        return [(f"{path}.content", block.get("content", []))]
+    return []
+
+
+def _validate_blocks(blocks: list, path: str) -> None:
+    """Validate every block against its schema, recursing into nested carriers.
+
+    `path` locates the current block list in error messages, e.g.
+    ``body[2].content[0]`` or ``body[1].items[0][3]``.
+    """
+    from klartex.block_engine import KNOWN_BLOCK_TYPES
+    from klartex.components import get_component
+
+    for i, block in enumerate(blocks):
+        where = f"{path}[{i}]"
+        if not isinstance(block, dict):
+            continue  # non-dict shapes are rejected by the carrier's schema
+        block_type = block.get("type")
+        if not block_type:
+            raise ValueError(f"Block at {where} is missing 'type'")
+        if block_type not in KNOWN_BLOCK_TYPES:
+            available = ", ".join(sorted(KNOWN_BLOCK_TYPES))
+            raise ValueError(
+                f"Unknown block type '{block_type}' at {where}. "
+                f"Available: {available}"
+            )
+        spec = get_component(block_type)
+        block_schema = spec.get_block_schema()
+        if block_schema:
+            try:
+                jsonschema.validate(block, block_schema)
+            except jsonschema.ValidationError as e:
+                raise ValueError(
+                    f"Invalid '{block_type}' block at {where}: {e.message}"
+                ) from e
+        for child_path, child_blocks in _child_block_lists(block, where):
+            _validate_blocks(child_blocks, child_path)
+
+
 def _restore_block_types(orig_blocks: list, esc_blocks: list) -> None:
     """Walk parallel block-arrays and copy unescaped `type` (and raw `latex.source`)
     from the original onto the escape-mangled copy.
 
-    Recurses into nested block carriers: ``list.items[].content[]`` and
-    ``columns.items[][]``.
+    Recurses into the nested block carriers listed by `_child_block_lists`.
     """
     for orig, esc in zip(orig_blocks, esc_blocks):
         if not isinstance(orig, dict) or not isinstance(esc, dict):
@@ -152,16 +209,10 @@ def _restore_block_types(orig_blocks: list, esc_blocks: list) -> None:
         esc["type"] = btype
         if btype == "latex" and "source" in orig:
             esc["source"] = orig["source"]
-        elif btype == "list":
-            for o_item, e_item in zip(orig.get("items", []), esc.get("items", [])):
-                if isinstance(o_item, dict) and isinstance(e_item, dict):
-                    _restore_block_types(o_item.get("content", []), e_item.get("content", []))
-        elif btype == "columns":
-            for o_col, e_col in zip(orig.get("items", []), esc.get("items", [])):
-                if isinstance(o_col, list) and isinstance(e_col, list):
-                    _restore_block_types(o_col, e_col)
-        elif btype == "clause":
-            _restore_block_types(orig.get("content", []), esc.get("content", []))
+        for (_, o_kids), (_, e_kids) in zip(
+            _child_block_lists(orig), _child_block_lists(esc)
+        ):
+            _restore_block_types(o_kids, e_kids)
 
 
 def _render_block_engine(
@@ -200,7 +251,7 @@ def _compile_tex(tex_source: str, asset_dir: Path | str | None = None) -> bytes:
 
         # Write .tex source
         tex_path = tmp / "document.tex"
-        tex_path.write_text(tex_source)
+        tex_path.write_text(tex_source, encoding="utf-8")
 
         # Symlink entire cls/ directory so xelatex can find .cls and .sty files
         (tmp / "cls").symlink_to(CLS_DIR)
@@ -224,19 +275,24 @@ def _compile_tex(tex_source: str, asset_dir: Path | str | None = None) -> bytes:
         # render user-supplied page templates that could otherwise execute
         # arbitrary shell commands during compilation.
         for _ in range(2):
-            result = subprocess.run(
-                [
-                    "xelatex",
-                    "-interaction=nonstopmode",
-                    "-halt-on-error",
-                    "-no-shell-escape",
-                    "document.tex",
-                ],
-                cwd=tmpdir,
-                capture_output=True,
-                timeout=30,
-                env=env,
-            )
+            try:
+                result = subprocess.run(
+                    [
+                        "xelatex",
+                        "-interaction=nonstopmode",
+                        "-halt-on-error",
+                        "-no-shell-escape",
+                        "document.tex",
+                    ],
+                    cwd=tmpdir,
+                    capture_output=True,
+                    timeout=60,
+                    env=env,
+                )
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError(
+                    f"xelatex timed out after {e.timeout:.0f}s"
+                ) from e
             if result.returncode != 0:
                 raise RuntimeError(
                     f"xelatex failed (exit {result.returncode}):\n"

--- a/klartex/schemas/blocks/signatures.schema.json
+++ b/klartex/schemas/blocks/signatures.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/signatures/v0.2",
+  "$id": "https://klartex.se/schemas/blocks/signatures/v0.3",
   "title": "Signatures Block",
   "description": "Signature block for one or more parties, laid out in a configurable number of columns",
   "type": "object",
@@ -9,6 +9,7 @@
   "properties": {
     "type": { "type": "string", "const": "signatures" },
     "new_page": { "type": "boolean", "default": true, "description": "Start signatures on a new page" },
+    "contract_intro": { "type": "boolean", "default": false, "description": "Rendera standardingressen 'Detta avtal har upprättats i två (2) likalydande exemplar, av vilka parterna tagit var sitt.' ovanför signaturerna. Sätt true för avtal; utelämna för dokument som inte är avtal." },
     "header": {
       "type": "string",
       "description": "Optional section header text shown above the signatures (e.g. 'Underskrifter'). Omit for no header."

--- a/klartex/templates/_block_engine.tex.jinja
+++ b/klartex/templates/_block_engine.tex.jinja
@@ -28,25 +28,23 @@
 \begin{document}
 
 %# --- Macro for rendering a party fieldset ---
+%# Optional lines are collected and joined with \\ so no branch needs to know
+%# whether another line follows it. Signatory is skipped when it equals the
+%# party name (same convention as the signature pane).
 \BLOCK{macro render_party(party, label, group="")}
-\fieldset[\VAR{group}]{\VAR{label}}{%
-\textbf{\VAR{party.name}}\\[0.3em]
-\BLOCK{if party.get("org_number")}
-Org.nr: \VAR{party.org_number}\\
-\BLOCK{endif}
-\BLOCK{if party.get("id_number")}
-Personnr: \VAR{party.id_number}\\
-\BLOCK{endif}
+\BLOCK{set _lines = [] }
+\BLOCK{if party.get("org_number")}\BLOCK{set _ = _lines.append("Org.nr: " ~ party.org_number) }\BLOCK{endif}
+\BLOCK{if party.get("id_number")}\BLOCK{set _ = _lines.append("Personnr: " ~ party.id_number) }\BLOCK{endif}
 \BLOCK{if party.get("address")}
-\VAR{party.address}
+\BLOCK{set _ = _lines.append(party.address) }
 \BLOCK{else}
-\BLOCK{if party.get("address_line1")}
-\VAR{party.address_line1}\\
+\BLOCK{if party.get("address_line1")}\BLOCK{set _ = _lines.append(party.address_line1) }\BLOCK{endif}
+\BLOCK{if party.get("address_line2")}\BLOCK{set _ = _lines.append(party.address_line2) }\BLOCK{endif}
 \BLOCK{endif}
-\BLOCK{if party.get("address_line2")}
-\VAR{party.address_line2}
-\BLOCK{endif}
-\BLOCK{endif}
+\BLOCK{if party.get("signatory") and party.signatory != party.name}\BLOCK{set _ = _lines.append("Företräds av: " ~ party.signatory) }\BLOCK{endif}
+\fieldset[\VAR{group}]{\VAR{label}}{%
+\textbf{\VAR{party.name}}\BLOCK{if _lines}\\[0.3em]
+\VAR{_lines | join("\\\\\n")}\BLOCK{endif}
 }
 \BLOCK{endmacro}
 
@@ -59,12 +57,12 @@ Personnr: \VAR{party.id_number}\\
 \\VAR{size_macro}
 \renewcommand{\arraystretch}{1.3}
 \setlength{\tabcolsep}{4pt}
-\noindent\begin{tabularx}{\linewidth}{@{}\BLOCK{for i in range(ncols)}\BLOCK{set col = (columns[i] if columns and i < (columns|length) else {}) }\BLOCK{set align = col.get("align", "left") if col else "left" }\BLOCK{set align_prefix = {"left": ">{\\raggedright\\arraybackslash}", "right": ">{\\raggedleft\\arraybackslash}", "center": ">{\\centering\\arraybackslash}"}.get(align, ">{\\raggedright\\arraybackslash}") }\BLOCK{set width = col.get("width", "fill") if col else "fill" }\BLOCK{if width == "fill"}\VAR{align_prefix}X\BLOCK{else}p{\VAR{width}}\BLOCK{endif}\BLOCK{endfor}@{}}
+\noindent\begin{tabularx}{\linewidth}{@{}\BLOCK{for i in range(ncols)}\BLOCK{set col = (columns[i] if columns and i < (columns|length) else {}) }\BLOCK{set align = col.get("align", "left") if col else "left" }\BLOCK{set align_prefix = {"left": ">{\\raggedright\\arraybackslash}", "right": ">{\\raggedleft\\arraybackslash}", "center": ">{\\centering\\arraybackslash}"}.get(align, ">{\\raggedright\\arraybackslash}") }\BLOCK{set width = col.get("width", "fill") if col else "fill" }\BLOCK{if width == "fill"}\VAR{align_prefix}X\BLOCK{else}\VAR{align_prefix}p{\VAR{width}}\BLOCK{endif}\BLOCK{endfor}@{}}
 \toprule
-\BLOCK{for cell in header}\textbf{\VAR{cell | inline}}\BLOCK{if not loop.last} & \BLOCK{endif}\BLOCK{endfor} \\
+\BLOCK{for cell in header}\textbf{\VAR{cell | inline_cell}}\BLOCK{if not loop.last} & \BLOCK{endif}\BLOCK{endfor} \\
 \midrule
 \BLOCK{for row in rows}
-\BLOCK{for cell in row}\VAR{cell | inline}\BLOCK{if not loop.last} & \BLOCK{endif}\BLOCK{endfor} \\\BLOCK{if not loop.last}\cmidrule[0.2pt]{1-\VAR{ncols}}\BLOCK{endif}
+\BLOCK{for cell in row}\VAR{cell | inline_cell}\BLOCK{if not loop.last} & \BLOCK{endif}\BLOCK{endfor} \\\BLOCK{if not loop.last}\cmidrule[0.2pt]{1-\VAR{ncols}}\BLOCK{endif}
 \BLOCK{endfor}
 \bottomrule
 \end{tabularx}
@@ -239,7 +237,7 @@ Personnr: \VAR{party.id_number}\\
 \addcontentsline{toc}{section}{\VAR{block.header}}
 \vspace{0.5cm}
 \BLOCK{endif}
-\BLOCK{if block.parties | length == 2}
+\BLOCK{if block.get("contract_intro")}
 \kxsignaturesintro
 
 \vspace{0.5cm}
@@ -267,7 +265,7 @@ Personnr: \VAR{party.id_number}\\
 \renewcommand{\arraystretch}{1.6}
 \noindent\begin{tabularx}{\linewidth}{@{}l >{\raggedright\arraybackslash}X@{}}
 \BLOCK{for field in block.fields}
-\textbf{\VAR{field.label | inline}:} & \BLOCK{if field.get('value')}\VAR{field.value | inline}\BLOCK{else}\dotfill\BLOCK{endif} \\
+\textbf{\VAR{field.label | inline_flat}:} & \BLOCK{if field.get('value')}\VAR{field.value | inline_cell}\BLOCK{else}\dotfill\BLOCK{endif} \\
 \BLOCK{endfor}
 \end{tabularx}
 \endgroup

--- a/klartex/templates/_recipe_base.tex.jinja
+++ b/klartex/templates/_recipe_base.tex.jinja
@@ -93,10 +93,10 @@ Org.nr: \VAR{comp.data.recipient.org_number}\\
 
 \begin{flushright}
 \begin{tabular}{lr}
-\textbf{Summa exkl. moms:} & \VAR{"{:,.2f}".format(subtotal.val)} \VAR{comp.data.get('currency', 'SEK')} \\
-\textbf{Moms:} & \VAR{"{:,.2f}".format(vat_total.val)} \VAR{comp.data.get('currency', 'SEK')} \\
+\textbf{Summa exkl. moms:} & \VAR{"{:,.2f}".format(subtotal.val)} \VAR{comp.data.get('currency') or 'SEK'} \\
+\textbf{Moms:} & \VAR{"{:,.2f}".format(vat_total.val)} \VAR{comp.data.get('currency') or 'SEK'} \\
 \midrule
-\textbf{Att betala:} & \textbf{\VAR{"{:,.2f}".format(subtotal.val + vat_total.val)} \VAR{comp.data.get('currency', 'SEK')}} \\
+\textbf{Att betala:} & \textbf{\VAR{"{:,.2f}".format(subtotal.val + vat_total.val)} \VAR{comp.data.get('currency') or 'SEK'}} \\
 \end{tabular}
 \end{flushright}
 

--- a/tests/fixtures/avtal_block.json
+++ b/tests/fixtures/avtal_block.json
@@ -100,6 +100,7 @@
     {
       "type": "signatures",
       "new_page": false,
+      "contract_intro": true,
       "parties": [
         { "name": "Uppdragsgivaren AB", "signatory": "Anna Andersson, VD" },
         { "name": "Erik Eriksson", "signatory": "Erik Eriksson" }

--- a/tests/test_block_engine.py
+++ b/tests/test_block_engine.py
@@ -1062,3 +1062,204 @@ class TestRecipeTemplatesStillWork:
         pdf = render("protokoll", data)
         assert pdf[:5] == b"%PDF-"
 
+
+
+def _render_tex(data: dict) -> str:
+    """Module helper: run the renderer's pre-compile pipeline and return the
+    rendered LaTeX source (no xelatex needed)."""
+    from klartex.renderer import _render_block_engine, _restore_block_types
+    from klartex.tex_escape import escape_data
+
+    escaped = escape_data(data)
+    _restore_block_types(data["body"], escaped["body"])
+    return _render_block_engine(escaped)
+
+
+class TestCellSafeLineBreaks:
+    """Literal \\n inside tabular cells must not become \\\\ — with
+    \\arraybackslash that ends the table row instead of breaking the line."""
+
+    def test_table_cell_newline_uses_newline_macro(self):
+        data = {"body": [{"type": "table", "header": ["A", "B"], "rows": [["x\ny", "z"]]}]}
+        tex = _render_tex(data)
+        assert r"x \newline y" in tex
+        assert r"x \\ y" not in tex
+
+    def test_table_header_cell_newline_uses_newline_macro(self):
+        data = {"body": [{"type": "table", "header": ["Lång\nrubrik", "B"], "rows": [["x", "z"]]}]}
+        tex = _render_tex(data)
+        assert r"Lång \newline rubrik" in tex
+
+    def test_form_value_newline_is_cell_safe(self):
+        data = {"body": [{"type": "form", "fields": [{"label": "Adress", "value": "Rad 1\nRad 2"}]}]}
+        tex = _render_tex(data)
+        assert r"Rad 1 \newline Rad 2" in tex
+
+    def test_form_label_newline_collapses_to_space(self):
+        """Labels sit in an LR-mode `l` column where no in-cell break exists."""
+        data = {"body": [{"type": "form", "fields": [{"label": "Två\nrader", "value": "x"}]}]}
+        tex = _render_tex(data)
+        assert "Två rader" in tex
+
+    def test_text_block_newline_still_paragraph_break(self):
+        data = {"body": [{"type": "text", "text": "rad 1\nrad 2"}]}
+        tex = _render_tex(data)
+        assert r"rad 1 \\ rad 2" in tex
+
+    @pytest.mark.skipif(not HAS_XELATEX, reason="xelatex not installed")
+    def test_cell_newlines_compile(self):
+        from klartex.renderer import render
+
+        data = {"body": [
+            {"type": "table", "header": ["Rubrik\nrad två", "B"], "rows": [["x\ny", "z"], ["a", "b"]]},
+            {"type": "form", "fields": [{"label": "Fält\nnamn", "value": "v1\nv2"}]},
+        ]}
+        pdf = render(BLOCK_ENGINE_TEMPLATE, data)
+        assert pdf[:5] == b"%PDF-"
+
+
+class TestNestedBlockValidation:
+    """Nested blocks (clause.content[], list.items[].content[], columns.items[][])
+    are validated against their own schemas, with a path in the error."""
+
+    def test_nested_list_missing_items_rejected(self):
+        from klartex.renderer import render
+
+        data = {"body": [{"type": "clause", "number": "§ 1", "content": [{"type": "list"}]}]}
+        with pytest.raises(ValueError, match=r"Invalid 'list' block at body\[0\]\.content\[0\]"):
+            render(BLOCK_ENGINE_TEMPLATE, data)
+
+    def test_nested_text_missing_text_rejected(self):
+        from klartex.renderer import render
+
+        data = {"body": [{"type": "list", "items": [{"text": "punkt", "content": [{"type": "text"}]}]}]}
+        with pytest.raises(ValueError, match=r"Invalid 'text' block at body\[0\]\.items\[0\]\.content\[0\]"):
+            render(BLOCK_ENGINE_TEMPLATE, data)
+
+    def test_columns_nested_block_validated(self):
+        from klartex.renderer import render
+
+        data = {"body": [{"type": "columns", "items": [[{"type": "text"}]]}]}
+        with pytest.raises(ValueError, match=r"Invalid 'text' block at body\[0\]\.items\[0\]\[0\]"):
+            render(BLOCK_ENGINE_TEMPLATE, data)
+
+    def test_unknown_type_reports_path(self):
+        from klartex.renderer import render
+
+        data = {"body": [{"type": "foo"}]}
+        with pytest.raises(ValueError, match=r"Unknown block type 'foo' at body\[0\]"):
+            render(BLOCK_ENGINE_TEMPLATE, data)
+
+    def test_valid_nested_document_passes(self):
+        """A correctly shaped nested document still renders to .tex."""
+        data = {"body": [
+            {"type": "clause", "number": "§ 1", "text": "Topp", "content": [
+                {"type": "list", "items": ["a", {"text": "b", "content": [
+                    {"type": "text", "text": "nested"},
+                ]}]},
+            ]},
+            {"type": "columns", "items": [[{"type": "text", "text": "kolumn"}]]},
+        ]}
+        tex = _render_tex(data)
+        assert "nested" in tex and "kolumn" in tex
+
+
+class TestSignaturesContractIntro:
+    """The contract boilerplate intro is opt-in via contract_intro, not
+    inferred from the party count."""
+
+    def test_two_parties_without_flag_has_no_intro(self):
+        data = {"body": [{"type": "signatures", "new_page": False,
+                          "parties": [{"name": "A"}, {"name": "B"}]}]}
+        tex = _render_tex(data)
+        assert r"\kxsignaturesintro" not in tex
+
+    def test_contract_intro_true_renders_intro(self):
+        data = {"body": [{"type": "signatures", "new_page": False, "contract_intro": True,
+                          "parties": [{"name": "A"}, {"name": "B"}]}]}
+        tex = _render_tex(data)
+        assert r"\kxsignaturesintro" in tex
+
+    def test_contract_intro_independent_of_party_count(self):
+        data = {"body": [{"type": "signatures", "new_page": False, "contract_intro": True,
+                          "parties": [{"name": "A"}, {"name": "B"}, {"name": "C"}]}]}
+        tex = _render_tex(data)
+        assert r"\kxsignaturesintro" in tex
+
+    def test_contract_intro_accepted_by_schema(self):
+        from klartex.renderer import render
+
+        data = {"body": [{"type": "signatures", "contract_intro": True,
+                          "parties": [{"name": "A"}]}]}
+        if HAS_XELATEX:
+            assert render(BLOCK_ENGINE_TEMPLATE, data)[:5] == b"%PDF-"
+        else:
+            _render_tex(data)
+
+
+class TestPartySignatory:
+    """parties.party*.signatory renders as a 'Företräds av' line, skipped
+    when it equals the party name (same convention as the signature pane)."""
+
+    def _data(self, party1, party2):
+        return {"body": [{"type": "parties", "party1": party1, "party2": party2}]}
+
+    def test_signatory_rendered_when_differs_from_name(self):
+        tex = _render_tex(self._data(
+            {"name": "Acme AB", "org_number": "556789-0123", "signatory": "Anna Andersson, VD"},
+            {"name": "Erik Eriksson"},
+        ))
+        assert "Företräds av: Anna Andersson, VD" in tex
+
+    def test_signatory_skipped_when_same_as_name(self):
+        tex = _render_tex(self._data(
+            {"name": "Erik Eriksson", "signatory": "Erik Eriksson"},
+            {"name": "Acme AB"},
+        ))
+        assert "Företräds av" not in tex
+
+    def test_address_still_renders(self):
+        tex = _render_tex(self._data(
+            {"name": "Acme AB", "address": "Storgatan 1, 111 22 Stockholm"},
+            {"name": "Erik Eriksson", "address_line1": "Lilla vägen 3", "address_line2": "222 33 Göteborg"},
+        ))
+        assert "Storgatan 1" in tex
+        assert "Lilla vägen 3" in tex
+
+
+class TestTableColumnAlign:
+    """align must apply also when a fixed column width is given."""
+
+    def test_fixed_width_column_gets_align_prefix(self):
+        data = {"body": [{"type": "table", "header": ["A", "B"], "rows": [["1", "2"]],
+                          "columns": [{"width": "3cm", "align": "right"}, {"align": "left"}]}]}
+        tex = _render_tex(data)
+        assert r">{\raggedleft\arraybackslash}p{3cm}" in tex
+
+    @pytest.mark.skipif(not HAS_XELATEX, reason="xelatex not installed")
+    def test_fixed_width_aligned_table_compiles(self):
+        from klartex.renderer import render
+
+        data = {"body": [{"type": "table", "header": ["A", "B"], "rows": [["1", "2"]],
+                          "columns": [{"width": "3cm", "align": "right"}, {"align": "center"}]}]}
+        assert render(BLOCK_ENGINE_TEMPLATE, data)[:5] == b"%PDF-"
+
+
+class TestTitlePageOptionalParties:
+    """title_page without parties renders only the title — no stray 'Och'
+    or blank party rows (handled inside \\makedoctitle)."""
+
+    @pytest.mark.skipif(not HAS_XELATEX, reason="xelatex not installed")
+    def test_title_only_and_single_party_compile(self):
+        from klartex.renderer import render
+
+        data = {"body": [
+            {"type": "title_page", "title": "Verksamhetsberättelse 2025"},
+            {"type": "title_page", "party1": "Föreningen X", "title": "Stadgar"},
+        ]}
+        assert render(BLOCK_ENGINE_TEMPLATE, data)[:5] == b"%PDF-"
+
+    def test_title_only_passes_empty_party_args(self):
+        data = {"body": [{"type": "title_page", "title": "Bara titel"}]}
+        tex = _render_tex(data)
+        assert r"\makedoctitle{}{}{Bara titel}" in tex

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,53 @@
+"""Tests for CLI error handling: invalid JSON, directory input, unwritable output."""
+
+import json
+import shutil
+
+import pytest
+from typer.testing import CliRunner
+
+from klartex.cli import app
+
+HAS_XELATEX = shutil.which("xelatex") is not None
+
+runner = CliRunner()
+
+
+def _all_output(result) -> str:
+    """stdout + stderr regardless of click version (mix_stderr or not)."""
+    out = result.output
+    try:
+        out += result.stderr
+    except (ValueError, AttributeError):
+        pass
+    return out
+
+
+def test_invalid_json_stdin_gives_friendly_error():
+    result = runner.invoke(app, [], input="{not json")
+    assert result.exit_code == 1
+    assert "invalid JSON" in _all_output(result)
+
+
+def test_invalid_json_file_gives_friendly_error(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{trasig", encoding="utf-8")
+    result = runner.invoke(app, ["-d", str(bad)])
+    assert result.exit_code == 1
+    assert "invalid JSON" in _all_output(result)
+
+
+def test_directory_as_data_path_gives_friendly_error(tmp_path):
+    result = runner.invoke(app, ["-d", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "not a file" in _all_output(result)
+
+
+@pytest.mark.skipif(not HAS_XELATEX, reason="xelatex not installed")
+def test_unwritable_output_reports_error_after_render(tmp_path):
+    data = tmp_path / "doc.json"
+    data.write_text(json.dumps({"body": [{"type": "text", "text": "hej"}]}), encoding="utf-8")
+    out = tmp_path / "finns-inte" / "ut.pdf"
+    result = runner.invoke(app, ["-d", str(data), "-o", str(out)])
+    assert result.exit_code == 1
+    assert "could not write" in _all_output(result)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -92,3 +92,42 @@ class TestDiscovery:
         registry = get_registry()
         assert "_block" in registry
         assert registry["_block"].is_block_engine
+
+
+def _render_recipe_tex(template_name: str, data: dict) -> str:
+    """Helper: run the recipe pre-compile pipeline, return the LaTeX source."""
+    from klartex.renderer import _render_recipe
+    from klartex.tex_escape import escape_data
+
+    info = get_registry()[template_name]
+    return _render_recipe(info, escape_data(data))
+
+
+def test_faktura_missing_currency_defaults_to_sek():
+    """extract_component_data inserts None for missing data_map paths, so the
+    template must not rely on dict-get defaults (the key exists, value None)."""
+    import jsonschema
+
+    data = json.loads((FIXTURES / "faktura.json").read_text())
+    del data["currency"]
+    jsonschema.validate(data, get_registry()["faktura"].get_validation_schema())
+
+    tex = _render_recipe_tex("faktura", data)
+    assert " None" not in tex
+    assert "SEK" in tex
+
+
+def test_xelatex_timeout_raises_runtime_error(monkeypatch):
+    """TimeoutExpired must be translated to the pipeline's RuntimeError contract."""
+    import subprocess
+
+    from klartex import renderer as renderer_mod
+
+    monkeypatch.setattr(renderer_mod.shutil, "which", lambda _: "/usr/bin/xelatex")
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="xelatex", timeout=60)
+
+    monkeypatch.setattr(renderer_mod.subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="timed out"):
+        renderer_mod._compile_tex("\\documentclass{article}\\begin{document}x\\end{document}")


### PR DESCRIPTION
Addresses all seven findings from the consolidated code review. Full test suite green locally (220 passed, no xelatex skips), 14 new tests.

## 1. Line break in table cell corrupts the table (most severe)
The `inline` filter converted `\n → \\` unconditionally. Inside a tabularx cell with `\arraybackslash`, `\\` ends the table row — `{"rows": [["x\ny", "z"]]}` cut the row after "x". New filter variants: **`inline_cell`** (`\newline`, for paragraph-mode p/X cells) used in table header/body cells and form values, **`inline_flat`** (space, for LR-mode cells) used in form labels. `text` blocks keep the `\\` behaviour.

## 2. Invoice without `currency` rendered "None"
`extract_component_data` inserts `None` for missing data_map paths, so `comp.data.get('currency', 'SEK')` found the key and the default never fired. Fixed with `get('currency') or 'SEK'` (template-side fix — stripping None keys in `extract_component_data` would have changed the contract for every component).

## 3. Nested blocks are now validated recursively
`clause.content[]`, `list.items[].content[]` and `columns.items[][]` are validated against their block schemas, with a path in the error: `Invalid 'list' block at body[0].content[0]`. The carrier list is extracted into `_child_block_lists()`, shared with `_restore_block_types` so validation and restore cannot drift apart. **Note:** top-level error format changes from `at index 2` to `at body[2]`.

## 4. `contract_intro` flag replaces the two-party heuristic (breaking)
`\kxsignaturesintro` ("Detta avtal har upprättats i två (2) likalydande exemplar…") triggered on `parties|length == 2` — five of the repo's own fixtures (revisionsberättelse, motion, etc.) claimed to be contracts. Now opt-in via `contract_intro: true` (schema v0.3, default false). The avtal fixture is updated. **Breaking:** two-party contracts without the flag lose the intro paragraph.

## 5. CLI error handling
Malformed JSON (stdin or file), a directory as `-d` path, and an unwritable `-o` path now produce `Error: …` + exit 1 instead of tracebacks. The write failure matters most: it fired *after* a successful multi-second render, losing the PDF bytes.

## 6. Schema fields that were silently dropped
- `parties.signatory` now renders as "Företräds av: …" (skipped when equal to the party name, same convention as the signature pane). `render_party` restructured into a uniform line list instead of special-cased trailing `\\`.
- Table column `align` now applies with a fixed `width` too (`>{\raggedleft\arraybackslash}p{3cm}`).
- `title_page` with only `title` no longer renders "Och" + blank party rows; a single party also works (`\makedoctitle` handles empty arguments).

## 7. Hardening
- `encoding="utf-8"` on all file I/O (renderer, registry, components, page_templates, cli).
- xelatex `TimeoutExpired` is translated to the pipeline's `RuntimeError` contract; timeout raised 30→60 s (a cold font cache in a fresh container could exceed 30 s on its own).
- The `formal` footer no longer prints a leading `•` when `\doctitle` is empty.

Deliberately left as-is: the CLI `-o` default still writes to cwd (judged intentional, standard CLI convention) — say the word if it should change.