### PR TITLE
Block spacing overrides: per-instance fields + document-level block_settings

### DIFF
--- a/klartex/block_engine.py
+++ b/klartex/block_engine.py
@@ -73,6 +73,7 @@ def prepare_block_context(
     return {
         "body": data["body"],
         "lang": data.get("lang", "sv"),
+        "block_settings": data.get("block_settings") or {},
         "page_template_source": page_template_source,
         "page_template": page_tmpl,
         "external_page_template": external_page_template,

--- a/klartex/schemas/block_engine.schema.json
+++ b/klartex/schemas/block_engine.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/block-engine/v0.1",
+  "$id": "https://klartex.se/schemas/block-engine/v0.2",
   "title": "Block Engine Document",
   "description": "Universal block-based document format. The agent composes body[] freely from typed blocks.",
   "type": "object",
@@ -31,6 +31,24 @@
       "enum": ["sv", "en"],
       "default": "sv",
       "description": "Document language"
+    },
+    "block_settings": {
+      "type": "object",
+      "description": "Document-wide spacing overrides keyed by block type name (e.g. 'heading', 'table'). Applies to every instance of that block type in the document; a per-instance spacing_before/spacing_after field on a block wins over this. Supported types: heading, text, list, table, callout, quote, description_list.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "spacing_before": {
+            "type": "string",
+            "description": "Vertical space above each instance. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time."
+          },
+          "spacing_after": {
+            "type": "string",
+            "description": "Vertical space below each instance. Same semantics as spacing_before."
+          }
+        }
+      }
     },
     "body": {
       "type": "array",

--- a/klartex/schemas/block_engine.schema.json
+++ b/klartex/schemas/block_engine.schema.json
@@ -41,7 +41,7 @@
         "properties": {
           "spacing_before": {
             "type": "string",
-            "description": "Vertical space above each instance. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time."
+            "description": "Vertical space above each instance. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time."
           },
           "spacing_after": {
             "type": "string",

--- a/klartex/schemas/blocks/callout.schema.json
+++ b/klartex/schemas/blocks/callout.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/callout/v0.1",
+  "$id": "https://klartex.se/schemas/blocks/callout/v0.2",
   "title": "Callout Block",
   "description": "Visually distinct notice box (info/tip/warning/danger/note).",
   "type": "object",
@@ -20,6 +20,14 @@
     "text": {
       "type": "string",
       "description": "Body text (single paragraph). Inline markup applies."
+    },
+    "spacing_before": {
+      "type": "string",
+      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+    },
+    "spacing_after": {
+      "type": "string",
+      "description": "Override the vertical space below this block. Same semantics as spacing_before."
     }
   }
 }

--- a/klartex/schemas/blocks/callout.schema.json
+++ b/klartex/schemas/blocks/callout.schema.json
@@ -23,7 +23,7 @@
     },
     "spacing_before": {
       "type": "string",
-      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+      "description": "Override the vertical space above this block. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
     },
     "spacing_after": {
       "type": "string",

--- a/klartex/schemas/blocks/description_list.schema.json
+++ b/klartex/schemas/blocks/description_list.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/description-list/v0.2",
+  "$id": "https://klartex.se/schemas/blocks/description-list/v0.3",
   "title": "Description List Block",
   "description": "Label/value definition list (HTML <dl>). Used for meeting metadata, party info, key-value displays — anywhere a sequence of label-value pairs needs to be rendered. Compose with the columns block for side-by-side layouts.",
   "type": "object",
@@ -21,6 +21,14 @@
         }
       },
       "minItems": 1
+    },
+    "spacing_before": {
+      "type": "string",
+      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+    },
+    "spacing_after": {
+      "type": "string",
+      "description": "Override the vertical space below this block. Same semantics as spacing_before."
     }
   }
 }

--- a/klartex/schemas/blocks/description_list.schema.json
+++ b/klartex/schemas/blocks/description_list.schema.json
@@ -24,7 +24,7 @@
     },
     "spacing_before": {
       "type": "string",
-      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+      "description": "Override the vertical space above this block. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
     },
     "spacing_after": {
       "type": "string",

--- a/klartex/schemas/blocks/heading.schema.json
+++ b/klartex/schemas/blocks/heading.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/heading/v0.2",
+  "$id": "https://klartex.se/schemas/blocks/heading/v0.3",
   "title": "Heading Block",
   "description": "Bold heading text with level and horizontal alignment.",
   "type": "object",
@@ -15,6 +15,14 @@
       "enum": ["left", "center", "right"],
       "default": "left",
       "description": "Horizontal alignment."
+    },
+    "spacing_before": {
+      "type": "string",
+      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+    },
+    "spacing_after": {
+      "type": "string",
+      "description": "Override the vertical space below this block. Same semantics as spacing_before."
     }
   }
 }

--- a/klartex/schemas/blocks/heading.schema.json
+++ b/klartex/schemas/blocks/heading.schema.json
@@ -18,7 +18,7 @@
     },
     "spacing_before": {
       "type": "string",
-      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+      "description": "Override the vertical space above this block. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
     },
     "spacing_after": {
       "type": "string",

--- a/klartex/schemas/blocks/list.schema.json
+++ b/klartex/schemas/blocks/list.schema.json
@@ -50,7 +50,7 @@
     },
     "spacing_before": {
       "type": "string",
-      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+      "description": "Override the vertical space above this block. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
     },
     "spacing_after": {
       "type": "string",

--- a/klartex/schemas/blocks/list.schema.json
+++ b/klartex/schemas/blocks/list.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/list/v0.2",
+  "$id": "https://klartex.se/schemas/blocks/list/v0.3",
   "title": "List Block",
   "description": "Bullet or numbered list. Items are strings, or objects with text + nested content blocks. Items pass through inline markup.",
   "type": "object",
@@ -47,6 +47,14 @@
           }
         ]
       }
+    },
+    "spacing_before": {
+      "type": "string",
+      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+    },
+    "spacing_after": {
+      "type": "string",
+      "description": "Override the vertical space below this block. Same semantics as spacing_before."
     }
   }
 }

--- a/klartex/schemas/blocks/quote.schema.json
+++ b/klartex/schemas/blocks/quote.schema.json
@@ -18,7 +18,7 @@
     },
     "spacing_before": {
       "type": "string",
-      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+      "description": "Override the vertical space above this block. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
     },
     "spacing_after": {
       "type": "string",

--- a/klartex/schemas/blocks/quote.schema.json
+++ b/klartex/schemas/blocks/quote.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/quote/v0.1",
+  "$id": "https://klartex.se/schemas/blocks/quote/v0.2",
   "title": "Quote Block",
   "description": "Typographic blockquote with optional attribution. Indented italic prose, attribution prefixed with em-dash.",
   "type": "object",
@@ -15,6 +15,14 @@
     "attribution": {
       "type": "string",
       "description": "Optional attribution line. Prefixed with em-dash on render."
+    },
+    "spacing_before": {
+      "type": "string",
+      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+    },
+    "spacing_after": {
+      "type": "string",
+      "description": "Override the vertical space below this block. Same semantics as spacing_before."
     }
   }
 }

--- a/klartex/schemas/blocks/table.schema.json
+++ b/klartex/schemas/blocks/table.schema.json
@@ -49,7 +49,7 @@
     },
     "spacing_before": {
       "type": "string",
-      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+      "description": "Override the vertical space above this block. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
     },
     "spacing_after": {
       "type": "string",

--- a/klartex/schemas/blocks/table.schema.json
+++ b/klartex/schemas/blocks/table.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/table/v0.1",
+  "$id": "https://klartex.se/schemas/blocks/table/v0.2",
   "title": "Table Block",
   "description": "Simple data table with header and rows. Cells pass through inline markup.",
   "type": "object",
@@ -46,6 +46,14 @@
       "type": "string",
       "enum": ["normal", "small", "footnotesize"],
       "default": "small"
+    },
+    "spacing_before": {
+      "type": "string",
+      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+    },
+    "spacing_after": {
+      "type": "string",
+      "description": "Override the vertical space below this block. Same semantics as spacing_before."
     }
   }
 }

--- a/klartex/schemas/blocks/text.schema.json
+++ b/klartex/schemas/blocks/text.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://klartex.se/schemas/blocks/text/v0.1",
+  "$id": "https://klartex.se/schemas/blocks/text/v0.2",
   "title": "Text Block",
   "description": "Free-form text paragraph",
   "type": "object",
@@ -8,6 +8,14 @@
   "additionalProperties": false,
   "properties": {
     "type": { "type": "string", "const": "text" },
-    "text": { "type": "string", "description": "Paragraph text" }
+    "text": { "type": "string", "description": "Paragraph text" },
+    "spacing_before": {
+      "type": "string",
+      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+    },
+    "spacing_after": {
+      "type": "string",
+      "description": "Override the vertical space below this block. Same semantics as spacing_before."
+    }
   }
 }

--- a/klartex/schemas/blocks/text.schema.json
+++ b/klartex/schemas/blocks/text.schema.json
@@ -11,7 +11,7 @@
     "text": { "type": "string", "description": "Paragraph text" },
     "spacing_before": {
       "type": "string",
-      "description": "Override the vertical space above this block. Any LaTeX dimension string ('1em', '0.5cm', '0em'). Not validated — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
+      "description": "Override the vertical space above this block. Plain-unit LaTeX dimension string ('1em', '0.5cm', '0em'). Macro-based dimensions ('\\baselineskip') are not supported — backslashes are escaped like in all other strings. Not validated beyond that — an invalid dimension fails at compile time. Wins over block_settings and the built-in default."
     },
     "spacing_after": {
       "type": "string",

--- a/klartex/templates/_block_engine.tex.jinja
+++ b/klartex/templates/_block_engine.tex.jinja
@@ -49,10 +49,10 @@
 \BLOCK{endmacro}
 
 %# --- Macro for simple data table (#26) ---
-\BLOCK{macro render_table(header, rows, columns, size)}
+\BLOCK{macro render_table(header, rows, columns, size, spacing_before="1em", spacing_after="1em")}
 \BLOCK{set ncols = header | length }
 \BLOCK{set size_macro = {"normal": "normalsize", "small": "small", "footnotesize": "footnotesize"}.get(size, "small") }
-\vspace{1em}
+\vspace{\VAR{spacing_before or "1em"}}
 \begingroup
 \\VAR{size_macro}
 \renewcommand{\arraystretch}{1.3}
@@ -67,7 +67,7 @@
 \bottomrule
 \end{tabularx}
 \endgroup
-\vspace{1em}
+\vspace{\VAR{spacing_after or "1em"}}
 
 \BLOCK{endmacro}
 
@@ -177,12 +177,18 @@
 %# Called from the top-level body loop and recursively from render_list for
 %# items with content[].
 \BLOCK{macro render_block(block, lang, suppress_needspace=false)}
+%# Effective spacing overrides for this block: per-instance field >
+%# document-level block_settings[type] > built-in default (applied per arm).
+%# Only the blocks that consume _sp_before/_sp_after below support overrides.
+\BLOCK{set _bs = block_settings.get(block.type, {}) if block_settings else {} }
+\BLOCK{set _sp_before = block.get('spacing_before') or _bs.get('spacing_before') }
+\BLOCK{set _sp_after = block.get('spacing_after') or _bs.get('spacing_after') }
 
 \BLOCK{if block.type == 'title_page'}
 \makedoctitle{\VAR{block.get('party1', '')}}{\VAR{block.get('party2', '')}}{\VAR{block.get('title', '')}}
 
 \BLOCK{elif block.type == 'heading'}
-\VAR{render_heading(block.text, block.get('level', 1), block.get('textAlign', 'left'), suppress_needspace)}
+\VAR{render_heading(block.text, block.get('level', 1), block.get('textAlign', 'left'), suppress_needspace, _sp_before, _sp_after)}
 
 \BLOCK{elif block.type == 'parties'}
 \vspace{3em}
@@ -198,13 +204,25 @@
 
 \BLOCK{elif block.type == 'text'}
 
+\BLOCK{if _sp_before}
+\vspace{\VAR{_sp_before}}
+\BLOCK{endif}
 \noindent \VAR{block.text | inline}
 
+\BLOCK{if _sp_after}
+\vspace{\VAR{_sp_after}}
+\BLOCK{endif}
 \BLOCK{elif block.type == 'list'}
+\BLOCK{if _sp_before}
+\vspace{\VAR{_sp_before}}
+\BLOCK{endif}
 \VAR{render_list(block["items"], block.get("style", "bullet"), lang)}
+\BLOCK{if _sp_after}
+\vspace{\VAR{_sp_after}}
+\BLOCK{endif}
 
 \BLOCK{elif block.type == 'table'}
-\VAR{render_table(block.header, block.rows, block.get("columns"), block.get("size", "small"))}
+\VAR{render_table(block.header, block.rows, block.get("columns"), block.get("size", "small"), _sp_before or "1em", _sp_after or "1em")}
 
 \BLOCK{elif block.type == 'callout'}
 \BLOCK{set _variant = block.get("variant", "note") }
@@ -212,12 +230,18 @@
 \BLOCK{set _default_titles_en = {"info": "Info", "tip": "Tip", "warning": "Note", "danger": "Warning", "note": "Note"} }
 \BLOCK{set _defaults = _default_titles_en if lang == "en" else _default_titles_sv }
 \BLOCK{set _title = block.get("title") if "title" in block else _defaults.get(_variant, "") }
+\BLOCK{if _sp_before}
+\vspace{\VAR{_sp_before}}
+\BLOCK{endif}
 \begin{callout}{\VAR{_variant}}{\VAR{_title | inline}}
 \VAR{block.text | inline}
 \end{callout}
+\BLOCK{if _sp_after}
+\vspace{\VAR{_sp_after}}
+\BLOCK{endif}
 
 \BLOCK{elif block.type == 'quote'}
-\vspace{2em}
+\vspace{\VAR{_sp_before or "2em"}}
 \begin{quote}\itshape
 \makebox[0pt][r]{\fontsize{36pt}{0pt}\selectfont\raisebox{-0.25em}{“}\hspace{0.15em}}\VAR{block.text | inline}”
 \BLOCK{if block.get("attribution")}
@@ -225,7 +249,7 @@
 \upshape\normalsize\hspace*{0pt}\textemdash\ \VAR{block.attribution | inline}
 \BLOCK{endif}
 \end{quote}
-\vspace{2em}
+\vspace{\VAR{_sp_after or "2em"}}
 
 \BLOCK{elif block.type == 'page_break'}
 \clearpage
@@ -298,7 +322,7 @@
 \BLOCK{endif}
 
 \BLOCK{elif block.type == 'description_list'}
-\VAR{render_description_list(block.entries)}
+\VAR{render_description_list(block.entries, _sp_before or "2em", _sp_after or "2em")}
 
 \BLOCK{elif block.type == 'agenda'}
 \VAR{render_agenda(block["items"], block.get('numberingStyle', 'section'), block.get('decisionLabel', 'Beslut:'))}

--- a/klartex/templates/_block_macros.tex.jinja
+++ b/klartex/templates/_block_macros.tex.jinja
@@ -8,11 +8,13 @@
 %# wraps the content in a center/flushright env. `suppress_needspace` skips
 %# the orphan-protection glue (used when this heading directly follows another
 %# heading whose own \kxneedspace already covers the buffer).
-\BLOCK{macro render_heading(text, level=1, textAlign="left", suppress_needspace=false)}
+%# spacing_before/spacing_after override the level-based defaults when set
+%# (block-engine spacing overrides, issue #29); recipe callers leave them unset.
+\BLOCK{macro render_heading(text, level=1, textAlign="left", suppress_needspace=false, spacing_before=none, spacing_after=none)}
 \BLOCK{set _size = "\\fontsize{24pt}{29pt}\\selectfont" if level == 1 else ("\\Large" if level == 2 else "\\large") }
 \BLOCK{set _needspace = "6\\baselineskip" if level == 1 else ("4\\baselineskip" if level == 2 else "3\\baselineskip") }
-\BLOCK{set _vspace_above = "2.0em" if level == 1 else ("1.4em" if level == 2 else "1.0em") }
-\BLOCK{set _vspace_below = "1.2em" if level == 1 else ("0.5em" if level == 2 else "0.15em") }
+\BLOCK{set _vspace_above = spacing_before if spacing_before else ("2.0em" if level == 1 else ("1.4em" if level == 2 else "1.0em")) }
+\BLOCK{set _vspace_below = spacing_after if spacing_after else ("1.2em" if level == 1 else ("0.5em" if level == 2 else "0.15em")) }
 \BLOCK{if not suppress_needspace}\kxneedspace{\VAR{_needspace}}\BLOCK{endif}
 \vspace{\VAR{_vspace_above}}
 \BLOCK{if textAlign == "center"}\begin{center}\BLOCK{elif textAlign == "right"}\begin{flushright}\BLOCK{endif}
@@ -24,15 +26,15 @@
 %# Render a label/value description list. `entries` is a list of {label, value}.
 %# Used by both the block-engine `description_list` block and recipes that map
 %# document metadata (date, location, attendees, …) to a label-value table.
-\BLOCK{macro render_description_list(entries)}
-\vspace{2em}
+\BLOCK{macro render_description_list(entries, spacing_before="2em", spacing_after="2em")}
+\vspace{\VAR{spacing_before or "2em"}}
 \noindent
 \begin{tabularx}{\linewidth}{@{}l >{\raggedright\arraybackslash}X@{}}
 \BLOCK{for entry in entries}
 \textbf{\VAR{entry.label}} & \VAR{entry.value} \\
 \BLOCK{endfor}
 \end{tabularx}
-\vspace{2em}
+\vspace{\VAR{spacing_after or "2em"}}
 \BLOCK{endmacro}
 
 %# Render the agenda block. `items` is a list of {title, discussion?, decision?, subItems?}.

--- a/tests/test_block_engine.py
+++ b/tests/test_block_engine.py
@@ -1263,3 +1263,112 @@ class TestTitlePageOptionalParties:
         data = {"body": [{"type": "title_page", "title": "Bara titel"}]}
         tex = _render_tex(data)
         assert r"\makedoctitle{}{}{Bara titel}" in tex
+
+
+class TestSpacingOverrides:
+    """Issue #29: per-instance spacing_before/spacing_after and document-level
+    block_settings, resolution per-instance > block_settings > default."""
+
+    def test_table_default_spacing(self):
+        data = {"body": [{"type": "table", "header": ["A"], "rows": [["1"]]}]}
+        tex = _render_tex(data)
+        assert tex.count(r"\vspace{1em}") == 2
+
+    def test_block_settings_overrides_default(self):
+        data = {
+            "block_settings": {"table": {"spacing_after": "2.5em"}},
+            "body": [{"type": "table", "header": ["A"], "rows": [["1"]]}],
+        }
+        tex = _render_tex(data)
+        assert r"\vspace{2.5em}" in tex
+        assert tex.count(r"\vspace{1em}") == 1  # before behåller default
+
+    def test_per_instance_beats_block_settings(self):
+        data = {
+            "block_settings": {"table": {"spacing_after": "2.5em"}},
+            "body": [{"type": "table", "header": ["A"], "rows": [["1"]], "spacing_after": "3em"}],
+        }
+        tex = _render_tex(data)
+        assert r"\vspace{3em}" in tex
+        assert r"\vspace{2.5em}" not in tex
+
+    def test_heading_spacing_before_overrides_level_default(self):
+        base = {"body": [{"type": "heading", "text": "Rubrik"}]}
+        assert r"\vspace{2.0em}" in _render_tex(base)
+
+        overridden = {"body": [{"type": "heading", "text": "Rubrik", "spacing_before": "0em"}]}
+        tex = _render_tex(overridden)
+        assert r"\vspace{0em}" in tex
+        assert r"\vspace{2.0em}" not in tex
+
+    def test_heading_block_settings_applies_to_all_levels(self):
+        data = {
+            "block_settings": {"heading": {"spacing_before": "0.7em"}},
+            "body": [
+                {"type": "heading", "text": "Ett", "level": 1},
+                {"type": "heading", "text": "Två", "level": 2},
+            ],
+        }
+        tex = _render_tex(data)
+        assert tex.count(r"\vspace{0.7em}") == 2
+        assert r"\vspace{2.0em}" not in tex
+        assert r"\vspace{1.4em}" not in tex
+
+    def test_text_has_no_spacing_by_default_but_gains_override(self):
+        base = {"body": [{"type": "text", "text": "hej"}]}
+        assert r"\vspace{4em}" not in _render_tex(base)
+
+        overridden = {"body": [{"type": "text", "text": "hej", "spacing_after": "4em"}]}
+        assert r"\vspace{4em}" in _render_tex(overridden)
+
+    def test_quote_keeps_default_when_unset(self):
+        data = {"body": [{"type": "quote", "text": "citat"}]}
+        tex = _render_tex(data)
+        assert tex.count(r"\vspace{2em}") == 2
+
+    def test_description_list_block_settings(self):
+        data = {
+            "block_settings": {"description_list": {"spacing_before": "0.5em", "spacing_after": "0.5em"}},
+            "body": [{"type": "description_list", "entries": [{"label": "Datum", "value": "2026-07-06"}]}],
+        }
+        tex = _render_tex(data)
+        assert tex.count(r"\vspace{0.5em}") == 2
+        assert r"\vspace{2em}" not in tex
+
+    def test_spacing_field_rejected_on_unsupported_block(self):
+        from klartex.renderer import render
+
+        data = {"body": [{"type": "signatures", "parties": [{"name": "A"}], "spacing_before": "1em"}]}
+        with pytest.raises(ValueError, match="Invalid 'signatures' block"):
+            render(BLOCK_ENGINE_TEMPLATE, data)
+
+    def test_malformed_block_settings_rejected(self):
+        import jsonschema
+
+        from klartex.renderer import render
+
+        data = {
+            "block_settings": {"heading": {"spacing_before": 5}},
+            "body": [{"type": "heading", "text": "x"}],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            render(BLOCK_ENGINE_TEMPLATE, data)
+
+    @pytest.mark.skipif(not HAS_XELATEX, reason="xelatex not installed")
+    def test_spacing_overrides_compile(self):
+        from klartex.renderer import render
+
+        data = {
+            "block_settings": {"heading": {"spacing_before": "1em"}, "table": {"spacing_after": "2em"}},
+            "body": [
+                {"type": "heading", "text": "Dokument"},
+                {"type": "text", "text": "Stycke.", "spacing_after": "2em"},
+                {"type": "table", "header": ["A", "B"], "rows": [["1", "2"]], "spacing_before": "0em"},
+                {"type": "list", "items": ["a", "b"], "spacing_before": "1.5em", "spacing_after": "1.5em"},
+                {"type": "callout", "text": "Obs", "spacing_before": "1em"},
+                {"type": "quote", "text": "Citat", "spacing_after": "0em"},
+                {"type": "description_list", "entries": [{"label": "Datum", "value": "Idag"}], "spacing_before": "1em"},
+            ],
+        }
+        pdf = render(BLOCK_ENGINE_TEMPLATE, data)
+        assert pdf[:5] == b"%PDF-"


### PR DESCRIPTION
Implements #29 (closes #29). Purely additive — no behavioural change for existing documents.

## Design (per the issue)

Resolution order: **per-instance `spacing_before`/`spacing_after` > `block_settings[type]` > built-in default**.

```json
{
  "block_settings": {
    "heading": {"spacing_before": "1em"},
    "table": {"spacing_after": "2em"}
  },
  "body": [
    {"type": "text", "text": "...", "spacing_after": "2em"}
  ]
}
```

Values are raw LaTeX dimension strings, deliberately unvalidated per the issue design — an invalid dimension fails at compile time. `"0em"` removes default spacing explicitly.

## Scope

Seven blocks: `heading`, `text`, `list`, `table`, `callout`, `quote`, `description_list`. The issue predates the 0.10 cleanup — its `metadata_table` is today's `description_list`, and `adjuster_signatures` no longer exists. Per-level heading granularity, a spacer block, and dimension validation are out of scope as specified.

## Implementation

- **Schemas**: optional `spacing_before`/`spacing_after` on the seven block schemas ($id bumped); `block_settings` object at the top level of `block_engine.schema.json` (value shape validated, keys open). Unsupported blocks reject the fields via their existing `additionalProperties: false`.
- **`block_engine.py`**: `block_settings` (default `{}`) added to the Jinja context. Keys survive escaping — `escape_data` leaves dict keys untouched (verified before building).
- **`_block_engine.tex.jinja`**: effective spacing resolved once at the top of `render_block`; `table`/`quote`/`description_list` had their hardcoded `\vspace` replaced, `text`/`list`/`callout` emit `\vspace` only when an override is set (no default spacing today, none added).
- **`_block_macros.tex.jinja`**: `render_heading`/`render_description_list` gain optional spacing args with today's values as defaults — the recipe path calls them unchanged and renders byte-identically.

## Tests

11 new tests: all three resolution steps, heading level defaults vs uniform `block_settings`, rejection on unsupported blocks and malformed `block_settings`, plus an xelatex compile test exercising overrides on all seven block types. Full suite: 231 passed, no skips.