### PR TITLE
Template: kvitto (receipt)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -15,6 +15,7 @@ Klartex takes JSON data + template name and produces PDF via XeLaTeX. Can be use
 | `_block` | Universal block engine — the agent composes the document freely |
 | `protokoll` | Meeting minutes with agenda, decisions, and adjusters |
 | `faktura` | Invoice with line items, VAT, and payment information |
+| `kvitto` | Receipt with a simple items list, payment method, and total |
 | `resultatrakning` | Income statement with comparison years and notes |
 | `balansrakning` | Balance sheet with assets and liabilities/equity sections |
 | `budgetrapport` | Budget report with account codes, budget, and actuals |
@@ -106,7 +107,7 @@ Klartex uses a three-layer architecture:
 
 ### Rendering paths
 
-- **Recipe templates** (`protokoll`, `faktura`) — YAML recipes declaring components and data mappings
+- **Recipe templates** (`protokoll`, `faktura`, `kvitto`) — YAML recipes declaring components and data mappings
 - **Block engine** (`_block`) — The agent composes `body[]` freely from typed blocks
 
 ### Creating a YAML Recipe Template
@@ -137,7 +138,7 @@ components:
 schema: schema.json
 ```
 
-Available recipe components: `heading`, `description_list`, `agenda`, `text`, `resultatrakning`, `budgettabell`, `notapparat`, `invoice_header`, `invoice_recipient`, `invoice_table`, `payment_info`, `invoice_note`. The shared types (`agenda`, `description_list`, `heading`, `resultatrakning`, `budgettabell`, `notapparat`, `text`) render through the same macros as the block-engine path.
+Available recipe components: `heading`, `description_list`, `agenda`, `text`, `resultatrakning`, `budgettabell`, `notapparat`, `invoice_header`, `invoice_recipient`, `invoice_table`, `payment_info`, `invoice_note`, `receipt_header`, `receipt_table`. The shared types (`agenda`, `description_list`, `heading`, `resultatrakning`, `budgettabell`, `notapparat`, `text`) render through the same macros as the block-engine path.
 
 Block engine blocks: `heading`, `text`, `list`, `table`, `callout`, `quote`, `title_page`, `parties`, `clause`, `signatures`, `description_list`, `form`, `columns`, `agenda`, `name_roster`, `resultatrakning`, `budgettabell`, `notapparat`, `page_break`, `latex`.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Klartex tar JSON-data + mallnamn och producerar PDF via XeLaTeX. Kan användas s
 | `_block` | Universell blockmotor — agenten komponerar dokumentet fritt |
 | `protokoll` | Mötesprotokoll med dagordning, beslut och justerare |
 | `faktura` | Faktura med rader, moms och betalningsinformation |
+| `kvitto` | Kvitto med enkel radlista, betalsätt och totalbelopp |
 | `resultatrakning` | Resultaträkning med jämförelseår och noter |
 | `balansrakning` | Balansräkning med tillgångar och skulder/eget kapital |
 | `budgetrapport` | Budgetrapport med kontokoder, budget och utfall |
@@ -106,7 +107,7 @@ Klartex har en trelagers-arkitektur:
 
 ### Renderingsvägar
 
-- **Recipe-mallar** (`protokoll`, `faktura`) — YAML-recept som deklarerar komponenter och mappningar
+- **Recipe-mallar** (`protokoll`, `faktura`, `kvitto`) — YAML-recept som deklarerar komponenter och mappningar
 - **Block engine** (`_block`) — Agenten komponerar `body[]` fritt från typade block
 
 ### Skapa en YAML-receptmall
@@ -137,7 +138,7 @@ components:
 schema: schema.json
 ```
 
-Tillgängliga recept-komponenter: `heading`, `description_list`, `agenda`, `text`, `resultatrakning`, `budgettabell`, `notapparat`, `invoice_header`, `invoice_recipient`, `invoice_table`, `payment_info`, `invoice_note`. Block-motsvarigheterna (`agenda`, `description_list`, `heading`, `resultatrakning`, `budgettabell`, `notapparat`, `text`) renderas via samma delade makron som block-engine-vägen.
+Tillgängliga recept-komponenter: `heading`, `description_list`, `agenda`, `text`, `resultatrakning`, `budgettabell`, `notapparat`, `invoice_header`, `invoice_recipient`, `invoice_table`, `payment_info`, `invoice_note`, `receipt_header`, `receipt_table`. Block-motsvarigheterna (`agenda`, `description_list`, `heading`, `resultatrakning`, `budgettabell`, `notapparat`, `text`) renderas via samma delade makron som block-engine-vägen.
 
 Block engine-block: `heading`, `text`, `list`, `table`, `callout`, `quote`, `title_page`, `parties`, `clause`, `signatures`, `description_list`, `form`, `columns`, `agenda`, `name_roster`, `resultatrakning`, `budgettabell`, `notapparat`, `page_break`, `latex`.
 

--- a/agent-docs/issue/8-kvitto-receipt-template/index.md
+++ b/agent-docs/issue/8-kvitto-receipt-template/index.md
@@ -1,0 +1,27 @@
+# Issue #8: Template: kvitto (receipt)
+
+**Branch from:** main
+
+## Summary
+
+New `kvitto` recipe template — a lightweight payment confirmation (receipt number, date, simple items list, explicit total, payment method). Built on the recipe path like faktura, with two new recipe-only components (`receipt_header`, `receipt_table`) and reuse of `description_list` metadata and `invoice_note`.
+
+## Triage Status
+
+| Field | Value |
+|-------|-------|
+| **Ready to work** | Yes |
+| **Risk** | Low |
+| **Issue state** | Open, label `template`, unassigned, no milestone |
+| **Blockers** | None found (no blocker references in issue; no conflicting open plans) |
+
+## Plan Review
+
+**Status:** Reviewed
+**Reviewed:** 2026-07-06
+**Feedback:** Codex review applied: empty-metadata guard on the description_list arm made an explicit step, `amount: 0` vs missing-amount handling specified with `is not none` + focused test, component-registration assertions added to test scope, README component lists added to docs step.
+
+## Related Files
+
+- [plan.md](plan.md) - Full implementation plan
+- [progress.md](progress.md) - Implementation progress log

--- a/agent-docs/issue/8-kvitto-receipt-template/plan.md
+++ b/agent-docs/issue/8-kvitto-receipt-template/plan.md
@@ -1,0 +1,71 @@
+# Plan: Issue #8 — Template: kvitto (receipt)
+
+## Goal
+
+Add a `kvitto` (receipt) template as a new recipe: a payment confirmation that is deliberately lighter than faktura — receipt number, date, a simple items list, one explicit total, payment method. No VAT breakdown, no due date, no line-item price computation.
+
+## Approach
+
+**Recipe path, not block engine.** A kvitto is exactly the kind of stable transactional document the recipe path exists for (domain-shaped JSON from upstream systems, fixed layout), parallel to faktura. The block engine remains available for free-form receipts, but producers sending `{receipt_number, items, total_amount}` should not have to describe layout.
+
+**Reuse before build.** The recipe is composed from:
+
+- **New recipe-only components** (2): `receipt_header` and `receipt_table`. `invoice_header` cannot be reused — it hardcodes the "FAKTURA" title and a due-date line. `invoice_table` cannot be reused — it computes per-line `quantity × unit_price` and a VAT summary, which a receipt must not have.
+- **Existing mechanisms**: `description_list` + `document.metadata` (with `optional: true`) renders the payment-method/paid-by label-value pairs — no new component needed. `invoice_note` renders the optional footer note as-is (it is generic despite the name).
+
+**Design decisions carried over from the original plan** (still sound, re-validated against today's issue text):
+
+1. Items are `{description, amount?}` — a simple list, not the faktura quantity/unit/price model. Per-item amounts are informational only.
+2. `total_amount` is an explicit required field, never computed from items (item amounts are optional, so summation would be unreliable).
+3. `payment_method` is a free-text string ("Kontant", "Swish", "Kort", …).
+4. Seller identity comes from the page template (`\orgname`, logo) — no seller fields in the schema; the free-text `note` covers edge cases.
+
+**Currency handling:** follow the existing faktura pattern — `comp.data.get('currency') or 'SEK'` in the template arm. JSON-Schema `default` values are not injected at validation time, so the fallback must live in the template (see `test_faktura_missing_currency_defaults_to_sek`).
+
+## Steps
+
+1. **`klartex/templates/kvitto/schema.json`** — draft-07, same shape as faktura's schema.
+   - Required: `receipt_number` (string), `date` (string, YYYY-MM-DD), `total_amount` (number), `items` (array, minItems 1).
+   - `items[]`: object with required `description` (string), optional `amount` (number).
+   - Optional: `page_template` (enum formal/clean/none, default formal), `currency` (string, default SEK), `payment_method` (string), `paid_by` (string), `note` (string).
+   - Descriptions in the same style as faktura's schema.
+
+2. **`klartex/templates/kvitto/recipe.yaml`** — `template.name: kvitto`, `lang: sv`, `document.title: "Kvitto {{ data.receipt_number }}"`, `document.page_template: "{{ data.page_template | default('formal') }}"`.
+   - `document.metadata`: `payment_method` (label "Betalsätt", optional) and `paid_by` (label "Betalt av", optional).
+   - Components in order: `receipt_header` (data_map: receipt_number, date), `receipt_table` (data_map: items, total_amount, currency), `description_list`, `invoice_note` (data_map: note).
+
+3. **`klartex/components.py`** — two new recipe-only `ComponentSpec` entries (no `sty_package`, no `block_schema_path`, so they stay invisible to the block engine like the `invoice_*` family):
+   - `receipt_header` — "Right-aligned receipt header with number and date".
+   - `receipt_table` — "Receipt items list with optional per-item amounts and explicit total".
+
+4. **`klartex/templates/_recipe_base.tex.jinja`** — two new component arms, placed next to the `invoice_*` arms, plus one guard on an existing arm:
+   - `receipt_header`: mirror `invoice_header` (flushright, `\Large\bfseries KVITTO`, Nr, Datum) minus the due-date line.
+   - `receipt_table`: `tabularx` `{Xr}` with booktabs rules; each item row shows description and the amount column uses an explicit `item.get('amount') is not none` check — so `amount: 0` renders as `0.00`, and only a truly absent amount gives an empty cell. Below the table a flushright block with a single prominent line `\textbf{Summa:} \textbf{{:,.2f} {currency}}` using the explicit `total_amount`. No subtotal/VAT rows.
+   - Guard the existing `description_list` arm with `\BLOCK{if metadata}`: `recipe.py` skips `optional: true` metadata whose value is absent, so a kvitto without `payment_method`/`paid_by` yields `metadata == []`, and `render_description_list([])` would otherwise emit 4em of spacing around an empty `tabularx`. The guard is a no-op for protokoll (always has metadata).
+
+5. **`klartex/templates/kvitto/example.json`** — full example payload (all optional fields set). Required for `klartex example kvitto` (`cli.py` reads `templates/<name>/example.json`).
+
+6. **`tests/fixtures/kvitto.json`** — realistic fixture (förening use case: e.g. medlemsavgift paid via Swish), all fields populated.
+
+7. **Test updates:**
+   - `tests/test_schemas.py`: add `"kvitto"` to `test_discover_all_templates` and to the `test_fixture_validates` parametrize list.
+   - `tests/test_renderer.py`: add `"kvitto"` to the recipe parametrize list (line ~23) and a `test_kvitto_discovered` alongside `test_faktura_discovered`; xelatex render test comes free via the parametrized full-pipeline test.
+   - `tests/test_components.py`: assert `receipt_header` and `receipt_table` are registered, with `sty_package is None` and `block_schema_path is None`, next to the existing recipe-only component assertions (~line 122).
+   - Add a focused test rendering items with one missing amount and one `amount: 0` — the zero must render as `0.00`, the missing one as an empty cell — and assert `total_amount` appears formatted.
+   - Add a minimal-payload render test (no metadata fields set) asserting the description_list output is absent (empty-metadata guard).
+
+8. **Docs:** add a `kvitto` row to the template tables in `README.md` and `README.en.md`, extend the recipe-template enumerations (`protokoll`, `faktura`, …), and add `receipt_header`/`receipt_table` to the recipe-component lists (~line 140) in both files.
+
+## Risks
+
+- **Low overall.** Registry auto-discovers `recipe.yaml + schema.json`; no registry or CLI changes needed.
+- `_recipe_base.tex.jinja` is shared by all recipes — the new `elif` arms are additive, but the `description_list` guard (step 4) touches an arm used by protokoll; the guard only changes the `metadata == []` case, which no existing recipe hits. Covered by the existing protokoll render tests.
+- Jinja number formatting: `total_amount` arrives as int or float from JSON; `"{:,.2f}".format()` handles both (same as faktura lines).
+
+## Test Plan
+
+- `pytest` — full suite including new kvitto tests (fixture validation, discovery, xelatex compile).
+- `klartex -d tests/fixtures/kvitto.json -t kvitto -o /tmp/kvitto.pdf` — visual check: lighter than faktura, total prominent, no VAT.
+- Render a minimal payload (only required fields) — no payment method, no note, no per-item amounts.
+- `klartex templates` lists kvitto; `klartex schema kvitto` and `klartex example kvitto` return the new schema/example.
+- LaTeX-special characters in `description`/`note` (e.g. `50%`, `A&B`) render escaped.

--- a/agent-docs/issue/8-kvitto-receipt-template/progress.md
+++ b/agent-docs/issue/8-kvitto-receipt-template/progress.md
@@ -1,0 +1,19 @@
+# Progress: Issue #8 — Template: kvitto (receipt)
+
+## Status: Completed (2026-07-06)
+
+(Update as work proceeds — newest entries first)
+
+- 2026-07-06: All steps implemented and verified. Full suite 237 passed (6 new tests).
+  Rendered fixture and minimal payload via CLI; visual check OK (header, items,
+  prominent total, metadata list, note). `klartex templates`/`schema kvitto`/
+  `example kvitto` all work.
+
+- [x] 1. templates/kvitto/schema.json
+- [x] 2. templates/kvitto/recipe.yaml
+- [x] 3. components.py: receipt_header + receipt_table specs
+- [x] 4. _recipe_base.tex.jinja: new arms + description_list guard
+- [x] 5. templates/kvitto/example.json
+- [x] 6. tests/fixtures/kvitto.json
+- [x] 7. Test updates (test_schemas, test_renderer, test_components, focused tests)
+- [x] 8. README.md + README.en.md

--- a/klartex/components.py
+++ b/klartex/components.py
@@ -182,6 +182,16 @@ _COMPONENTS: dict[str, ComponentSpec] = {
         sty_package=None,
         description="Optional invoice footer note",
     ),
+    "receipt_header": ComponentSpec(
+        name="receipt_header",
+        sty_package=None,
+        description="Right-aligned receipt header with number and date",
+    ),
+    "receipt_table": ComponentSpec(
+        name="receipt_table",
+        sty_package=None,
+        description="Receipt items list with optional per-item amounts and explicit total",
+    ),
 }
 
 

--- a/klartex/templates/_recipe_base.tex.jinja
+++ b/klartex/templates/_recipe_base.tex.jinja
@@ -26,7 +26,11 @@
 \BLOCK{endif}
 
 \BLOCK{elif comp.type == 'description_list'}
+%# All optional metadata may have been skipped (recipe.py drops optional
+%# fields with missing values) — render nothing rather than an empty table.
+\BLOCK{if metadata}
 \VAR{render_description_list(metadata)}
+\BLOCK{endif}
 
 \BLOCK{elif comp.type == 'agenda'}
 \VAR{render_agenda(comp.data.get('items', []), comp.options.get('numberingStyle', 'section'), comp.options.get('decisionLabel', 'Beslut:'))}
@@ -124,6 +128,38 @@ Org.nr: \VAR{comp.data.recipient.org_number}\\
 \vspace{1em}
 \noindent\textit{\VAR{comp.data.note}}
 \BLOCK{endif}
+
+\BLOCK{elif comp.type == 'receipt_header'}
+\begin{flushright}
+{\Large\bfseries KVITTO}\\[0.5em]
+{\normalsize Nr: \VAR{comp.data.get('receipt_number', '')}}\\
+{\normalsize Datum: \VAR{comp.data.get('date', '')}}
+\end{flushright}
+
+\vspace{1em}
+
+\BLOCK{elif comp.type == 'receipt_table'}
+\begin{tabularx}{\textwidth}{Xr}
+\toprule
+\textbf{Beskrivning} & \textbf{Belopp} \\
+\midrule
+\BLOCK{for item in comp.data.get('items', [])}
+%# `is not none` (not truthiness): amount 0 must render as 0.00, only a
+%# truly absent amount gives an empty cell.
+\VAR{item.description} & \BLOCK{if item.get('amount') is not none}\VAR{"{:,.2f}".format(item.amount)}\BLOCK{endif} \\
+\BLOCK{endfor}
+\bottomrule
+\end{tabularx}
+
+\vspace{1em}
+
+\begin{flushright}
+\begin{tabular}{lr}
+\textbf{Summa:} & \textbf{\VAR{"{:,.2f}".format(comp.data.total_amount)} \VAR{comp.data.get('currency') or 'SEK'}} \\
+\end{tabular}
+\end{flushright}
+
+\vspace{1em}
 
 \BLOCK{elif comp.type == 'resultatrakning'}
 \VAR{render_resultatrakning(comp.data.rubrik_ar1, comp.data.rubrik_ar2, comp.data.grupper, comp.data.get('resultat'), comp.options.get('section_heading'))}

--- a/klartex/templates/kvitto/example.json
+++ b/klartex/templates/kvitto/example.json
@@ -1,0 +1,13 @@
+{
+  "receipt_number": "2026-014",
+  "date": "2026-07-06",
+  "total_amount": 350,
+  "currency": "SEK",
+  "payment_method": "Swish",
+  "paid_by": "Anna Andersson",
+  "items": [
+    { "description": "Medlemsavgift 2026", "amount": 250 },
+    { "description": "Nyckeldeposition", "amount": 100 }
+  ],
+  "note": "Tack för din betalning!"
+}

--- a/klartex/templates/kvitto/recipe.yaml
+++ b/klartex/templates/kvitto/recipe.yaml
@@ -1,0 +1,37 @@
+# Kvitto (Receipt) — recipe definition
+
+template:
+  name: kvitto
+  description: "Kvitto / Receipt"
+  lang: sv
+
+document:
+  title: "Kvitto {{ data.receipt_number }}"
+  page_template: "{{ data.page_template | default('formal') }}"
+  metadata:
+    - field: payment_method
+      label: "Betalsätt"
+      optional: true
+    - field: paid_by
+      label: "Betalt av"
+      optional: true
+
+components:
+  - type: receipt_header
+    data_map:
+      receipt_number: receipt_number
+      date: date
+
+  - type: receipt_table
+    data_map:
+      items: items
+      total_amount: total_amount
+      currency: currency
+
+  - type: description_list
+
+  - type: invoice_note
+    data_map:
+      note: note
+
+schema: schema.json

--- a/klartex/templates/kvitto/schema.json
+++ b/klartex/templates/kvitto/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Kvitto",
+  "description": "Kvitto / Receipt",
+  "type": "object",
+  "required": ["receipt_number", "date", "total_amount", "items"],
+  "properties": {
+    "page_template": { "type": "string", "enum": ["formal", "clean", "none"], "default": "formal", "description": "Page template" },
+    "receipt_number": { "type": "string" },
+    "date": { "type": "string", "description": "Receipt date (YYYY-MM-DD)" },
+    "total_amount": { "type": "number", "description": "Total amount paid. Authoritative — never computed from items." },
+    "currency": { "type": "string", "default": "SEK" },
+    "payment_method": { "type": "string", "description": "e.g. Kontant, Swish, Kort" },
+    "paid_by": { "type": "string", "description": "Name of the payer" },
+    "items": {
+      "type": "array",
+      "description": "What was paid for. Amounts are optional and informational — total_amount is the authoritative total.",
+      "items": {
+        "type": "object",
+        "required": ["description"],
+        "properties": {
+          "description": { "type": "string" },
+          "amount": { "type": "number" }
+        }
+      },
+      "minItems": 1
+    },
+    "note": { "type": "string", "description": "Footer note" }
+  }
+}

--- a/tests/fixtures/kvitto.json
+++ b/tests/fixtures/kvitto.json
@@ -1,0 +1,13 @@
+{
+  "receipt_number": "2026-014",
+  "date": "2026-07-06",
+  "total_amount": 350,
+  "currency": "SEK",
+  "payment_method": "Swish",
+  "paid_by": "Anna Andersson",
+  "items": [
+    { "description": "Medlemsavgift 2026", "amount": 250 },
+    { "description": "Nyckeldeposition", "amount": 100 }
+  ],
+  "note": "Tack för din betalning!"
+}

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -124,6 +124,13 @@ class TestComponentRegistry:
         spec = get_component("invoice_header")
         assert spec.block_schema_path is None or spec.get_block_schema() is not None
 
+    def test_receipt_components_registered(self):
+        """Recipe-only receipt components (issue #8): registered, no sty, no block schema."""
+        for name in ["receipt_header", "receipt_table"]:
+            spec = get_component(name)
+            assert spec.sty_package is None
+            assert spec.block_schema_path is None
+
 
 class TestResolveDataPath:
     """Tests for dot-notation data path resolution."""

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -20,7 +20,7 @@ def test_unknown_template():
 
 @pytest.mark.skipif(not HAS_XELATEX, reason="xelatex not installed")
 @pytest.mark.parametrize("template_name", [
-    "protokoll", "faktura",
+    "protokoll", "faktura", "kvitto",
     "resultatrakning", "balansrakning", "budgetrapport", "sie-exportrapport",
 ])
 def test_render_pdf(template_name):
@@ -82,6 +82,12 @@ class TestDiscovery:
         info = registry["faktura"]
         assert info.recipe_path is not None
 
+    def test_kvitto_discovered(self):
+        registry = get_registry()
+        assert "kvitto" in registry
+        info = registry["kvitto"]
+        assert info.recipe_path is not None
+
     def test_financial_templates_discovered(self):
         registry = get_registry()
         for name in ["resultatrakning", "balansrakning", "budgetrapport", "sie-exportrapport"]:
@@ -115,6 +121,39 @@ def test_faktura_missing_currency_defaults_to_sek():
     tex = _render_recipe_tex("faktura", data)
     assert " None" not in tex
     assert "SEK" in tex
+
+
+def test_kvitto_zero_amount_renders_missing_amount_empty():
+    """amount: 0 must render as 0.00; a missing amount gives an empty cell.
+    total_amount is authoritative and always rendered."""
+    data = {
+        "receipt_number": "K-1",
+        "date": "2026-07-06",
+        "total_amount": 100,
+        "items": [
+            {"description": "Gratisrad", "amount": 0},
+            {"description": "Rad utan belopp"},
+        ],
+    }
+    tex = _render_recipe_tex("kvitto", data)
+    assert r"Gratisrad & 0.00 \\" in tex
+    assert r"Rad utan belopp &  \\" in tex
+    assert "100.00" in tex
+
+
+def test_kvitto_minimal_payload_skips_metadata_list():
+    """Without payment_method/paid_by all optional metadata is dropped and the
+    description_list component must render nothing (no empty tabularx)."""
+    data = {
+        "receipt_number": "K-2",
+        "date": "2026-07-06",
+        "total_amount": 50,
+        "items": [{"description": "Avgift"}],
+    }
+    tex = _render_recipe_tex("kvitto", data)
+    assert r"\begin{tabularx}{\linewidth}" not in tex  # description_list table
+    assert "Betalsätt" not in tex
+    assert " None" not in tex
 
 
 def test_xelatex_timeout_raises_runtime_error(monkeypatch):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -15,6 +15,7 @@ def test_discover_all_templates():
     registry = get_registry()
     assert "protokoll" in registry
     assert "faktura" in registry
+    assert "kvitto" in registry
     assert "resultatrakning" in registry
     assert "balansrakning" in registry
     assert "budgetrapport" in registry
@@ -23,7 +24,7 @@ def test_discover_all_templates():
 
 
 @pytest.mark.parametrize("template_name", [
-    "protokoll", "faktura",
+    "protokoll", "faktura", "kvitto",
     "resultatrakning", "balansrakning", "budgetrapport", "sie-exportrapport",
 ])
 def test_fixture_validates(template_name):


### PR DESCRIPTION
Implements #8 (closes #8). New `kvitto` (receipt) recipe template — a payment confirmation deliberately lighter than faktura: receipt number, date, simple items list, one explicit total, payment method. No VAT breakdown, no due date, no price computation.

## Design

Recipe path (like faktura), composed from two new recipe-only components plus existing mechanisms:

- **`receipt_header`** — flushright KVITTO / Nr / Datum (mirrors `invoice_header` minus the due-date line)
- **`receipt_table`** — `{Xr}` items table where per-item amounts are optional and informational; `amount: 0` renders as `0.00` via an explicit `is not none` check. Below it a single prominent `Summa:` line from the authoritative `total_amount` field (never computed from items)
- **Reused:** `description_list` + `document.metadata` (`optional: true`) for Betalsätt/Betalt av; `invoice_note` for the footer note. Seller identity comes from the page template (`\orgname`) — no seller fields in the schema

One shared-file change beyond the additive arms: the `description_list` arm in `_recipe_base.tex.jinja` is now guarded with `if metadata`, so a minimal kvitto (no payment fields) renders nothing instead of 4em of spacing around an empty tabularx. No-op for protokoll, which always has metadata.

Currency follows the faktura pattern (`comp.data.get('currency') or 'SEK'`) since `extract_component_data` inserts `None` for missing data_map paths.

## Files

- `klartex/templates/kvitto/` — `schema.json`, `recipe.yaml`, `example.json` (registry auto-discovers; `klartex example kvitto` works)
- `klartex/components.py` — two recipe-only `ComponentSpec` entries
- `klartex/templates/_recipe_base.tex.jinja` — two new arms + metadata guard
- `tests/` — fixture + kvitto in discovery/fixture/render parametrizations, component registration, focused tests for zero/missing amounts and minimal payload
- `README.md` / `README.en.md` — template table, recipe enumeration, component list

## Tests

Full suite: 237 passed (6 new), no skips. Verified via CLI: fixture and minimal payload (incl. `50% & moms` special chars) render to PDF; visual check of the fixture PDF looks clean — right-aligned header, items table, prominent total, metadata list, note.

Plan and progress log in `agent-docs/issue/8-kvitto-receipt-template/` (plan was codex-reviewed before implementation).
